### PR TITLE
Remove jimcarroll.com due to newsletter popup

### DIFF
--- a/smallweb.txt
+++ b/smallweb.txt
@@ -3176,7 +3176,6 @@ https://jhey.dev/rss/rss.xml
 https://jibin.tech/rss.xml
 https://jiby.tech/index.xml
 https://jim-mcbeath.blogspot.com/feeds/posts/default
-https://jimcarroll.com/feed/
 https://jimleff.blogspot.com/feeds/posts/default
 https://jimmeruk.com/feed
 https://jimmitchell.org/feed


### PR DESCRIPTION
https://jimcarroll.com/2023/09/daily-inspiration-skills-development-be-tomorrow-today/ shows a newsletter popup, see screenshot below:

![image](https://github.com/kagisearch/smallweb/assets/6241083/9639a8d1-899e-40f8-9b0b-f620c6fc7d04)
