### PR TITLE
Remove eatsleepcycle.com from smallweb.txt

### DIFF
--- a/smallweb.txt
+++ b/smallweb.txt
@@ -5841,7 +5841,6 @@ https://www.duncanmackenzie.net/index.xml
 https://www.dwarkeshpatel.com/feed
 https://www.dylanpaulus.com/rss.xml
 https://www.eastlondonlines.co.uk/feed/
-https://www.eatsleepcycle.com/journal/feed/
 https://www.ebiester.com/feed.xml
 https://www.echevarria.io/rss.xml
 https://www.ecliptik.com/feed.xml


### PR DESCRIPTION
It is a commercial website, which doesn't fit [Kagi's definition of small web](https://blog.kagi.com/small-web): "the non-commercial part of the web, crafted by individuals to express themselves or share knowledge without seeking any financial gain."

![Screenshot_20230917-112007_Firefox_Nightly](https://github.com/kagisearch/smallweb/assets/28467304/1a932133-2c87-42fe-a8c2-b75de13a7204)


