### PR TITLE
Removing davidgerard.co.uk due to Patreon + Ebook sales + Affiliate Links

### DIFF
--- a/smallweb.txt
+++ b/smallweb.txt
@@ -3317,7 +3317,6 @@ https://davidduchemin.com/feed
 https://davidepstein.com/feed
 https://davidffisher.com/feed
 https://davidfq.me/feed.xml
-https://davidgerard.co.uk/blockchain/feed
 https://davidgildeh.com/feed
 https://davidgow.net/updates.rss
 https://davidhampgonsalves.com/index.xml


### PR DESCRIPTION
Removed https://davidgerard.co.uk/blockchain/feed

Site contains Amazon affiliate links, Patreon subscription for up to $100/month and ebook sales links in sidebar of every blog post.

I assume this is against the rules for smallweb.