### PR TITLE
Removed jpmens.net - site blocks cross-origin framing

### DIFF
--- a/smallweb.txt
+++ b/smallweb.txt
@@ -5161,7 +5161,6 @@ https://jpadilla.com/feed
 https://jpawlik.com/blog/feed/
 https://jpieper.com/feed
 https://jpkoning.blogspot.com/feeds/posts/default
-https://jpmens.net/atom.xml
 https://jpminda.com/feed
 https://jpreston.xyz/feed.xml
 https://jrhawley.ca/feed.xml


### PR DESCRIPTION
> curl -I https://jpmens.net/2023/09/22/notes-to-self-on-woodpecker-ci/
HTTP/2 200
date: Sat, 23 Sep 2023 16:11:51 GMT
content-type: text/html; charset=UTF-8
content-length: 12389
vary: Accept-Encoding
server: nginx
last-modified: Fri, 22 Sep 2023 15:32:27 GMT
etag: "3065-605f450e0527f"
accept-ranges: bytes
x-follow-me: @jpmens
x-pavatar: http://jpmens.net/inc/pavatar.png
x-xss-protection: 1; mode=block
permissions-policy: interest-cohort=()
x-content-type-options: nosniff
strict-transport-security: max-age=31536000
x-frame-options: SAMEORIGIN
referrer-policy: strict-origin-when-cross-origin