### PR TITLE
Remove adamharkus.com, advertisements, tracking, ..

### DIFF
--- a/smallweb.txt
+++ b/smallweb.txt
@@ -1124,7 +1124,6 @@ https://adamcraven.com/writing/index.xml
 https://adamenglebright.com/rss
 https://adamfaliq.wordpress.com/feed
 https://adamgreenough.me/feed
-https://adamharkus.com/feed
 https://adamj.eu/tech/atom.xml
 https://adamjuliangoldstein.com/feed.xml
 https://adammcnamara.com/feed


### PR DESCRIPTION
The website uses a lot of cookies, has a big subscribe & donate button right in front of the page.
![image](https://github.com/kagisearch/smallweb/assets/39312332/08a26994-f1d5-49e5-a973-3c5c85851e1e)
It has a lot of Facebook, Twitter, etc stuff in the bottom and posts about [5 Effective ways to maximise Google AdSense revenue](https://adamharkus.com/5-effective-ways-to-maximise-google-adsense-revenue/), [Win A Free Guitar Wireless System!](https://adamharkus.com/win-a-free-guitar-wireless-system/) and sponsored posts like [this one](https://adamharkus.com/back-to-school-with-yamaha-and-guitar-center/), advertising for guitar special offers at some online shop in cooperation with them. 

I feel like this is out of place in the 'small web'.