### PR TITLE
Add Web Engineering TIL feeds to smallweb.txt

### DIFF
--- a/smallweb.txt
+++ b/smallweb.txt
@@ -321,6 +321,7 @@ http://furrowedmiddlebrow.blogspot.com/feeds/posts/default
 http://fusion94.org/feed.xml
 http://fuzzyblog.io/blog/feed.xml
 http://gael-varoquaux.info/feeds/all.atom.xml
+http://gaiety.life/til.xml
 http://galoisrepresentations.wordpress.com/feed
 http://gavinandresen.ninja/feed
 http://geomblog.blogspot.com/atom.xml
@@ -407,6 +408,7 @@ http://laurelsplutoblog.blogspot.com/feeds/posts/default
 http://lazyprogrammer.me/feed
 http://lblutherie.blogspot.com/feeds/posts/default
 http://lebo.io/atom.xml
+http://leebyron.com/til/feed.xml
 http://leejo.github.io/feed.xml
 http://left-and-to-the-back.blogspot.com/feeds/posts/default
 http://lhzhang.com/atom.xml
@@ -622,6 +624,7 @@ http://thmatters.wordpress.com/feed
 http://throneofsalt.blogspot.com/feeds/posts/default
 http://timvieira.github.io/blog/atom.xml
 http://timworthington.blogspot.com/feeds/posts/default
+http://til.simonwillison.net/tils/feed.atom
 http://tinyshopww.blogspot.com/feeds/posts/default
 http://tirkarthi.github.io/feed.xml
 http://tolkienandfantasy.blogspot.com/feeds/posts/default


### PR DESCRIPTION
I have a TIL blog at gaiety.life/til, and it's inspired by the work other people do. These are small web projects that could get more views and I think they fit nicely into Kagi Small Web.