### PR TITLE
Remove www.coffeecoffeeandmorecoffee.com due to it lacking SSL

### DIFF
--- a/smallweb.txt
+++ b/smallweb.txt
@@ -690,7 +690,6 @@ http://www.chrisvogt.me/rss.xml
 http://www.chrisyin.com/feed.xml
 http://www.cleverhans.io/feed.xml
 http://www.codeovereasy.com/feed
-http://www.coffeecoffeeandmorecoffee.com/atom.xml
 http://www.countbayesie.com/blog?format=RSS
 http://www.creativedeletion.com/feed.xml
 http://www.crystae.net/feed.xml


### PR DESCRIPTION
This site is throwing an SSL error when opened in the Kagi Small Web website.

I am using the latest version of Firefox.

Navigating directly to www.coffeecoffeeandmorecoffee.com works fine... they just don't have SSL setup. Unfortunate, as the content looks cool.

<img width="1270" alt="Screenshot 2023-10-02 at 2 29 37 PM" src="https://github.com/kagisearch/smallweb/assets/1664093/d18e4a21-d37b-4f02-b373-47b678cca501">
