### PR TITLE
Optimize Dockerfile for improved cleanup and smaller image size

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -7,18 +7,17 @@ ENV BUCKET kagi-us-central1-smallweb
 ENV PORT 8080
 
 RUN set -e; \
-    apt-get update -y && apt-get install -y \
+    apt-get update -y && apt-get install --no-install-recommends -y \
     libpq-dev \
     curl \
     gcc \
     tini \
     lsb-release \
     wget \
-    fuse
-
-RUN wget https://github.com/GoogleCloudPlatform/gcsfuse/releases/download/v1.2.0/gcsfuse_1.2.0_amd64.deb
-RUN dpkg -i gcsfuse_1.2.0_amd64.deb
-RUN apt-get clean
+    fuse && \
+    wget https://github.com/GoogleCloudPlatform/gcsfuse/releases/download/v1.2.0/gcsfuse_1.2.0_amd64.deb && \
+    dpkg -i gcsfuse_1.2.0_amd64.deb && \
+    rm -rf gcsfuse_1.2.0_amd64.deb /var/lib/apt/lists/*
 
 WORKDIR /app
 
@@ -26,7 +25,7 @@ COPY gcsfuse_run.sh gcsfuse_run.sh
 RUN chmod +x gcsfuse_run.sh
 
 COPY app/requirements.txt requirements.txt
-RUN pip3 install -r requirements.txt
+RUN pip3 install --no-cache-dir -r requirements.txt
 
 COPY app/ .
 EXPOSE $PORT


### PR DESCRIPTION
This commit optimizes the Dockerfile to enhance the cleanup process and reduce the resulting image size. The changes are as follows:

1. Consolidated the `wget`, `dpkg`, and removal of the downloaded .deb file and apt `/var/lib/apt/lists/*` into a single `RUN` command. This effectively reduces the image size as the cleanup occurs in the same Docker layer. This approach replaces the unnecessary `apt-get clean` that is automatically performed in Debian/Ubuntu base images.

2. Use `--no-install-recommends` flag with `apt-get install` to prevent unnecessary packages from being installed.

3. Apply `--no-cache-dir` flag when using `pip install` to prevent caching and reduce image size.

These changes result in a more efficient Docker build process and a smaller, cleaner final Docker image. Specifically, the image size was reduced from 977MB to 949MB, as you can see below.

```
$ docker images
REPOSITORY     TAG          IMAGE ID       CREATED          SIZE
smallweb       after        7206ce8c6966   12 minutes ago   949MB
smallweb       before       c92947befbe9   12 minutes ago   977MB
```