### PR TITLE
Remove Substack feeds

### DIFF
--- a/smallweb.txt
+++ b/smallweb.txt
@@ -497,7 +497,6 @@ https://alvaromontoro.com/feed.rss
 https://alvin.codes/rss.xml
 https://alvinbunk.wordpress.com/feed/
 https://aly.arriqaaq.com/rss/
-https://amadeuspagel.com/feed
 https://amalelmohtar.com/rss/
 https://amandapeyton.com/blog/feed/
 https://amanhimself.dev/rss.xml
@@ -844,7 +843,6 @@ https://baileysbeerblog.blogspot.com/feeds/posts/default
 https://bajkowski.com/rss/
 https://bakedbean.org.uk/index.xml
 https://bala.sh/feed/
-https://balajis.com/feed
 https://balanarayan.com/feed/
 https://baligu.blogspot.com/feeds/posts/default
 https://balintorecastle.blogspot.com/feeds/posts/default
@@ -1074,7 +1072,6 @@ https://blog.0xbadc0de.be/feed
 https://blog.8bitbuddhism.com/feed/
 https://blog.aaronbieber.com/posts/index.xml
 https://blog.aaronkharris.com/posts.atom
-https://blog.abor.dev/feed
 https://blog.academicbiz.com/atom.xml
 https://blog.acolyer.org/feed/
 https://blog.adamchalmers.com/atom.xml
@@ -1172,7 +1169,6 @@ https://blog.choibean.com/feeds/posts/default
 https://blog.chrisrowbury.com/feeds/posts/default
 https://blog.christianperone.com/feed/
 https://blog.christianposta.com/feed.xml
-https://blog.christoolivier.com/feed
 https://blog.christopherburg.com/feed/
 https://blog.christophersmart.com/feed/
 https://blog.christophetd.fr/feed/
@@ -1253,7 +1249,6 @@ https://blog.efitz.net/rss/
 https://blog.eiler.eu/index.xml
 https://blog.einval.com/index.rss
 https://blog.einval.eu/index.xml
-https://blog.eladgil.com/feed
 https://blog.eldrid.ge/post/index.xml
 https://blog.emacsen.net/atom.xml
 https://blog.emilburzo.com/index.xml
@@ -1359,7 +1354,6 @@ https://blog.janestreet.com/feed.xml
 https://blog.janetacarr.com/rss/
 https://blog.janissary.xyz/feed.xml
 https://blog.jasper.la/index.xml
-https://blog.jatan.space/feed
 https://blog.jayparkinsonmd.com/feed/
 https://blog.jbowen.dev/index.xml
 https://blog.jchw.io/rss/
@@ -1507,7 +1501,6 @@ https://blog.monotonous.org/feed/atom/index.xml
 https://blog.mrmeyer.com/feed/
 https://blog.muffn.io/posts/index.xml
 https://blog.natbat.net/rss
-https://blog.nateliason.com/feed
 https://blog.nawaz.org/feeds/all.atom.xml
 https://blog.ncase.me/feed.xml
 https://blog.ncase.me/rss/
@@ -1700,7 +1693,6 @@ https://blog.timac.org/index.xml
 https://blog.timo.page/feed.xml
 https://blog.timparkinson.net/feed/
 https://blog.tingping.se/feed.xml
-https://blog.tjcx.me/feed
 https://blog.tjll.net/feed.xml
 https://blog.tmm.cx/feed/
 https://blog.tobiasrevell.com/feed/
@@ -1731,7 +1723,6 @@ https://blog.viraptor.info/feeds/all.rss.xml
 https://blog.vito.nyc/index.xml
 https://blog.vivekhaldar.com/rss
 https://blog.vivekpanyam.com/rss/
-https://blog.viveksrinivasan.com/feed
 https://blog.vjeux.com/feed
 https://blog.vmsplice.net/feeds/posts/default
 https://blog.vrypan.net/rss.xml
@@ -1866,7 +1857,6 @@ https://brainfood.xyz/index.xml
 https://brajeshwar.com/feed.xml
 https://bram.dingelstad.works/index.xml
 https://bram.is/feed.xml
-https://bramcohen.com/feed
 https://brandinho.github.io/feed.xml
 https://brandonbyars.com/feed/
 https://brandonrozek.com/blog/index.xml
@@ -1964,7 +1954,6 @@ https://bubbaone.blogspot.com/feeds/posts/default
 https://buddhism-for-vampires.com/rss.xml
 https://bugs.xdavidhu.me/feed.xml
 https://build-its-inprogress.blogspot.com/feeds/posts/default
-https://build.typogram.co/feed
 https://buildingbetterteams.de/profiles/brian-graham?format=rss
 https://buildingourpast.com/feed/
 https://buildingsofnewengland.com/feed/
@@ -2091,7 +2080,6 @@ https://cbea.ms/rss/
 https://cboy.space/index.xml
 https://cbui.dev/rss/
 https://ccampbell.io/index.xml
-https://ccleve.com/feed
 https://ccmixterblog.blogspot.com/feeds/posts/default
 https://cdacamar.github.io/feed.xml
 https://cdevroe.com/feed/index.rss
@@ -2425,7 +2413,6 @@ https://crgwbr.com/rss/
 https://cri.dev/rss.xml
 https://crippledscholar.com/feed/
 https://crisis40.com/english/index.xml
-https://crispychicken.cc/feed
 https://critical-inference.com/feed/
 https://critter.blog/feed/
 https://crocidb.com/index.xml
@@ -2461,7 +2448,6 @@ https://cutebouncingbunnies.wordpress.com/feed/
 https://cweiske.de/feeds/news.xml
 https://cweiske.de/tagebuch/feed/
 https://cwickham.blogspot.com/feeds/posts/default
-https://cyb3rsecurity.tips/feed
 https://cyber.wtf/feed/
 https://cyberarms.wordpress.com/feed/
 https://cyberchris.xyz/index.xml
@@ -3184,7 +3170,6 @@ https://everetttest.wordpress.com/feed/
 https://evertpot.com/atom.xml
 https://everttimberg.io/blog/index.xml
 https://everything.delivery/index.xml
-https://everything.intellectronica.net/feed
 https://everything.typepad.com/blog/atom.xml
 https://everythingchanges.us/feed.xml
 https://everythingfunctional.wordpress.com/feed/
@@ -5088,7 +5073,6 @@ https://krebsonsecurity.com/feed/
 https://krishallett.wordpress.com/feed/
 https://krishashok.me/feed/
 https://kristaps.me/feed.rss
-https://kristapsmors.com/feed
 https://kristerw.github.io/feed.xml
 https://kristinberkey-abbott.blogspot.com/feeds/posts/default
 https://kristoff.it/index.xml
@@ -5195,11 +5179,9 @@ https://leahneukirchen.org/blog/index.atom
 https://leancrew.com/all-this/feed/
 https://leanrada.com/rss.xml
 https://learnanalyticshere.wordpress.com/feed/
-https://learnandburn.ai/feed
 https://learnbyexample.github.io/atom.xml
 https://learnetto.com/blog/rss
 https://learningfrommymistakesenglish.blogspot.com/feeds/posts/default
-https://learnings.aleixmorgadas.dev/feed
 https://learningspy.co.uk/feed/
 https://leastprivilege.com/feed/
 https://leaverou.me/feed/
@@ -6123,8 +6105,6 @@ https://newscrewdriver.com/feed/
 https://newsfromnorfolk.uk/feed/
 https://newsletter.danhon.com/rss.xml
 https://newsletter.disappearingmoment.com/rss.xml
-https://newsletter.eng-leadership.com/feed
-https://newsletter.envisioning.io/feed
 https://newsletter.nixers.net/feed.xml
 https://nextlevelchess.blog/feed/
 https://nezhar.com/feeds/all.atom.xml
@@ -6908,7 +6888,6 @@ https://rdist.root.org/feed/
 https://rdvlivefromtokyo.blogspot.com/feeds/posts/default
 https://re-factor.blogspot.com/feeds/posts/default
 https://re-ws.pl/feed/
-https://read.lukeburgis.com/feed
 https://readbroca.com/rss.xml
 https://reading19001950.wordpress.com/feed/
 https://readingdoonesbury.com/feed/
@@ -7173,7 +7152,6 @@ https://ryanandrewlangdon.com/feed/
 https://ryanashcraft.com/rss/
 https://ryanbanderson.com/feed
 https://ryanbigg.com/feed.xml
-https://ryanblakeley.net/feed
 https://ryancaldbeck.co/feed/
 https://ryangjchandler.co.uk/feed
 https://ryanharter.com/index.xml
@@ -8045,7 +8023,6 @@ https://thenumb.at/feed.xml
 https://theoryclass.wordpress.com/feed/
 https://theorydish.blog/feed/
 https://theotherside.timsbrannan.com/feeds/posts/default
-https://theovershoot.co/feed
 https://theoverspill.blog/feed/
 https://thepassingtramp.blogspot.com/feeds/posts/default
 https://thepatronsaintofsuperheroes.wordpress.com/feed/
@@ -8703,7 +8680,6 @@ https://www.abhaynikam.me/rss.xml
 https://www.abhijitbhaduri.com/blog?format=rss
 https://www.abhinavomprakash.com/index.xml
 https://www.abiggercamera.com/feed/
-https://www.abortretry.fail/feed
 https://www.abstractmachines.dev/rss/
 https://www.abubalay.com/feed.xml
 https://www.acelinguist.com/feeds/posts/default
@@ -8724,7 +8700,6 @@ https://www.agwa.name/blog/feed
 https://www.ahalbert.com/feed.xml
 https://www.aidancooper.co.uk/rss/
 https://www.aidanwoods.com/latest.atom
-https://www.aisnakeoil.com/feed
 https://www.aiweirdness.com/rss/
 https://www.akalin.com/feed/atom
 https://www.akati.me/feed.xml
@@ -8840,7 +8815,6 @@ https://www.badspacecomics.com/blog-feed.xml
 https://www.bagofnothing.com/feed/
 https://www.baldurbjarnason.com/index.xml
 https://www.banane.com/feed/
-https://www.barbariangrunge.com/feed
 https://www.barbarianmeetscoding.com/atom.xml
 https://www.bartoszsypytkowski.com/rss/
 https://www.bartvandersanden.com/feed.xml
@@ -9002,7 +8976,6 @@ https://www.cjcid.com/feeds/all.xml
 https://www.classicfilmtvcafe.com/feeds/posts/default
 https://www.claudiokuenzler.com/rss.xml
 https://www.cleverhans.io/feed.xml
-https://www.climaticthoughts.com/feed
 https://www.cmason.com/feed.xml
 https://www.cobblerandbard.com/feed/
 https://www.cocktailsandcoffee.com/feed.rss
@@ -9018,7 +8991,6 @@ https://www.codevscolor.com/rss.xml
 https://www.codewithjason.com/feed/
 https://www.codewithlinda.com/rss.xml
 https://www.codingnagger.com/feed/
-https://www.codingvc.com/feed
 https://www.codingwithjesse.com/blog/feed
 https://www.codingwithricky.com/rss2.xml
 https://www.coeneedell.com/post/index.xml
@@ -9026,7 +8998,6 @@ https://www.colby.so/atom.xml
 https://www.cold-takes.com/rss/
 https://www.colino.net/wordpress/feed/
 https://www.complete-review.com/saloon/rss.xml
-https://www.computerenhance.com/feed
 https://www.confluent.io/rss.xml
 https://www.conniewonnie.com/feeds/posts/default
 https://www.conradakunga.com/blog/feed.xml
@@ -9034,7 +9005,6 @@ https://www.conscienceround.com/feed
 https://www.content-technologist.com/rss/
 https://www.copetti.org/index.xml
 https://www.coppolacomment.com/feeds/posts/default
-https://www.corbettbarr.com/feed
 https://www.corbinstreehouse.com/blog/feed/
 https://www.coryetzkorn.com/feed.xml
 https://www.coryzue.com/feed.xml
@@ -9159,7 +9129,6 @@ https://www.dummies-for-destruction.co.uk/random/feed/
 https://www.duncanmackenzie.net/blog/index.xml
 https://www.dusterwald.com/feed/
 https://www.dutchosintguy.com/blog-feed.xml
-https://www.dwarkeshpatel.com/feed
 https://www.dylanpaulus.com/rss.xml
 https://www.dzombak.com/atom.xml
 https://www.eadan.net/index.xml
@@ -9184,7 +9153,6 @@ https://www.electricmonk.nl/log/feed/
 https://www.electrospaces.net/feeds/posts/default
 https://www.elegantframework.com/feeds/feed.xml
 https://www.elidedbranches.com/feeds/posts/default
-https://www.elidourado.com/feed
 https://www.elijahlynn.net/rss.xml
 https://www.elinace.com/journal?format=rss
 https://www.eliseomartelli.it/feed.xml
@@ -9273,12 +9241,10 @@ https://www.g1a55er.net/feed.xml
 https://www.galacticbeyond.com/rss/
 https://www.galoisrepresentations.com/feed/
 https://www.gannetdesigns.com/feed/
-https://www.garbageday.email/feed
 https://www.garethrees.co.uk/feed.xml
 https://www.garrensmith.com/rss/
 https://www.garron.blog/feed.rss
 https://www.garysieling.com/blog/feed/
-https://www.garyvarner.com/feed
 https://www.gasparevitta.com/rss.xml
 https://www.gautamnarula.com/feed/
 https://www.gautampk.com/feed.rss
@@ -9346,7 +9312,6 @@ https://www.harukizaemon.com/atom.xml
 https://www.haskellforall.com/feeds/posts/default
 https://www.haukeluebbers.de/blog/index.xml
 https://www.hawkins.io/index.xml
-https://www.hawkradius.com/feed
 https://www.hawksworx.com/feed.xml
 https://www.helenanderson.co.nz/feed/
 https://www.hellbox.co.uk/feed/
@@ -9394,7 +9359,6 @@ https://www.improveyoursocialskills.com/feed
 https://www.industrialempathy.com/feed/feed.xml
 https://www.inference.vc/rss/
 https://www.instigatorblog.com/feed/
-https://www.insurgent.ca/feed
 https://www.interfluidity.com/feed
 https://www.intergalacticprimate.com/feed/
 https://www.inthemargins.ca/feed.rss
@@ -9501,7 +9465,6 @@ https://www.jonathanklein.net/feeds/posts/default
 https://www.jonesish.com/blog?format=rss
 https://www.jonkensy.com/feed/
 https://www.jonnor.com/feed/
-https://www.jonstokes.com/feed
 https://www.jordanmechner.com/feed/
 https://www.josephamccullough.com/feed/
 https://www.josephkirwin.com/feed.xml
@@ -9574,13 +9537,11 @@ https://www.kleemans.ch/rss.xml
 https://www.kmjn.org/notes/recent.atom
 https://www.knittingpirate.com/feed/
 https://www.knuterikevensen.com/feed/
-https://www.kojevnikov.com/feed
 https://www.kooslooijesteijn.net/feed.xml
 https://www.krekr.nl/feed/
 https://www.kryogenix.org/days/feed
 https://www.kukulinski.com/rss/
 https://www.kuniga.me/feed.xml
-https://www.kuwi.news/feed
 https://www.kylenazario.com/rss.xml
 https://www.l1cafe.blog/atom.xml
 https://www.labbott.name/feed.xml
@@ -9764,7 +9725,6 @@ https://www.murilopereira.com/index.xml
 https://www.mymoneyblog.com/feed
 https://www.mysk.blog/feed/
 https://www.naleid.com/feed.xml
-https://www.namingthings.org/feed
 https://www.narendravardi.com/rss/
 https://www.natecation.com/rss.xml
 https://www.nathalielawhead.com/candybox/feed
@@ -9835,7 +9795,6 @@ https://www.omps.in/feed/
 https://www.onceuponasaga.dk/blog?format=feed&type=atom
 https://www.oncontracts.com/feed/
 https://www.onebigfluke.com/feeds/posts/default
-https://www.onmattersconcerningmyexistence.com/feed
 https://www.onswiftwings.com/index.xml
 https://www.openidealapp.com/feed/
 https://www.openmymind.net/atom.xml
@@ -9847,7 +9806,6 @@ https://www.otherstrangeness.com/feed/
 https://www.outcoldman.com/feed.xml
 https://www.outofthepastblog.com/feeds/posts/default
 https://www.outsidetheworld.com/feeds/posts/default
-https://www.overcomingbias.com/feed
 https://www.ovl.design/text/feed.xml
 https://www.ownml.co/blog?format=rss
 https://www.packing-up-the-pieces.com/feed/
@@ -9962,15 +9920,12 @@ https://www.reedbeta.com/feed
 https://www.refsmmat.com/rss.xml
 https://www.reitzen.com/index.xml
 https://www.relaycomputer.co.uk/index.xml
-https://www.residentcontrarian.com/feed
 https://www.resourceaholic.com/feeds/posts/default
 https://www.retailinsider.com/feed/
-https://www.retroist.com/feed
 https://www.reubence.com/rss/feed.xml
 https://www.reversemode.com/feeds/posts/default
 https://www.rewritethisstory.com/feeds/posts/default
 https://www.rexstjohn.com/feed/
-https://www.rfleury.com/feed
 https://www.rhyslindmark.com/rss/
 https://www.ribbonfarm.com/feed/
 https://www.rich-text.net/rss.xml
@@ -9979,7 +9934,6 @@ https://www.richardcallaby.com/feed/
 https://www.richardherring.com/warmingup/rss
 https://www.richardhughestherapy.com/blog-feed.xml
 https://www.richardrodger.com/feed/
-https://www.rickmanelius.com/feed
 https://www.ricksdailytips.com/feed/
 https://www.rickyterrell.com/?feed=rss2
 https://www.righto.com/feeds/posts/default
@@ -10077,7 +10031,6 @@ https://www.seancdavis.com/feed.xml
 https://www.seat31b.com/feed/
 https://www.sebastianhesse.de/feed/
 https://www.secretdesihistory.com/feed
-https://www.secwale.com/feed
 https://www.selfcommit.com/feeds/posts/default
 https://www.semicomplete.com/index.xml
 https://www.sergiomannino.com/insights?format=rss
@@ -10120,8 +10073,6 @@ https://www.smokingonabike.com/feed/
 https://www.snell-pym.org.uk/feed/
 https://www.snellman.net/blog/rss-index.xml
 https://www.software-artist.com/rss.xml
-https://www.softwareatscale.dev/feed
-https://www.softwareengineeringtidbits.com/feed
 https://www.softwaremaxims.com/feed.xml
 https://www.softwarepragmatism.com/?format=feed&type=rss
 https://www.sohamkamani.com/index.xml
@@ -10131,7 +10082,6 @@ https://www.sonyasupposedly.com/rss/
 https://www.soulcutter.com/feed.xml
 https://www.soundstep.com/feed.xml
 https://www.southernrockiesnatureblog.com/feeds/posts/default
-https://www.spakhm.com/feed
 https://www.sparklytrainers.com/feed/
 https://www.sparringmind.com/feed/
 https://www.spectrecollie.com/feed/
@@ -10165,13 +10115,11 @@ https://www.stevejgordon.co.uk/feed
 https://www.stevenbuccini.com/feed.xml
 https://www.stevenhicks.me/feed.xml
 https://www.steveonstuff.com/feed.xml
-https://www.stewfortier.com/feed
 https://www.stitchesontherun.com/rss/
 https://www.stjo.hn/feeds/rss.xml
 https://www.stochasticlifestyle.com/feed/
 https://www.storagezilla.xyz/storagezilla/atom.xml
 https://www.strangehistory.net/feed/
-https://www.strangeloopcanon.com/feed
 https://www.stuckinabook.com/feed/
 https://www.stumax.com/feed.xml
 https://www.subbu.org/index.xml
@@ -10226,7 +10174,6 @@ https://www.terriwindling.com/blog/atom.xml
 https://www.tewari.info/feed/
 https://www.textclad.com/feed/
 https://www.thanassis.space/rss.xml
-https://www.the-line-between.com/feed
 https://www.the100.ci/feed/
 https://www.the8bitguy.com/feed/
 https://www.theartofdoingstuff.com/feed/
@@ -10248,7 +10195,6 @@ https://www.thenordickitchen.com/feed/
 https://www.theoinglis.co.uk/rss
 https://www.thepassivevoice.com/feed/
 https://www.thepolyglotdeveloper.com/blog/index.xml
-https://www.thepullrequest.com/feed
 https://www.therodinhoods.com/feed/
 https://www.thescoop.org/blog.xml
 https://www.theskooloflife.com/feed/
@@ -10383,7 +10329,6 @@ https://www.woodlifestudio.com/feed/
 https://www.wowhaus.co.uk/feed/
 https://www.wurb.com/stack/feed
 https://www.wyeworks.com/rss.xml
-https://www.wysr.xyz/feed
 https://www.xceptance.com/en/feed.xml
 https://www.xitijpatel.com/rss/
 https://www.xmlaficionado.com/blog?format=rss


### PR DESCRIPTION
Remove Substack feeds with their own domain. Maybe a bit controversial? The content is sometimes good quality, but it seems to not work with the current iframe setup of the Kagi Small Web site. Also, there is no substack.com feeds in the list.