### PR TITLE
Remove Medium feeds

### DIFF
--- a/smallweb.txt
+++ b/smallweb.txt
@@ -268,7 +268,6 @@ https://adamenglebright.com/rss/
 https://adamfaliq.wordpress.com/feed/
 https://adamgreenough.me/feed/
 https://adamj.eu/tech/atom.xml
-https://adammcnamara.com/feed
 https://adammusciano.com/index.xml
 https://adamnash.blog/feed/
 https://adamsgaard.dk/atom.xml
@@ -347,7 +346,6 @@ https://ahitrin.github.io/feed.xml
 https://ahmet.im/blog/feed/rss.xml
 https://ahopeful.wordpress.com/feed/
 https://ahoylemon.xyz/feed.xml
-https://aidancunniffe.com/feed
 https://aigarius.com/feeds/rss/rss.xml
 https://aiimpacts.org/feed/
 https://ailef.tech/feed/
@@ -588,7 +586,6 @@ https://andys.page/index.xml
 https://andywarburton.co.uk/feed/
 https://ane.iki.fi/feed.xml
 https://aneccodeal.blogspot.com/feeds/posts/default
-https://anee.me/feed
 https://aneesh.mataroa.blog/rss/
 https://aneksteind.github.io/rss.xml
 https://angelariggs.github.io/feed.xml
@@ -917,7 +914,6 @@ https://ben.sanders.life/feed.xml
 https://benbrougher.tech/rss.xml
 https://benbyford.com/articles/rss
 https://bencheng.net/index.xml
-https://benchling.engineering/feed
 https://bencraven.org.uk/feed/
 https://bencrowder.net/blog/feed/
 https://bendyworks.com/feed/rss.xml
@@ -1081,7 +1077,6 @@ https://blog.adrianistan.eu/rss.xml
 https://blog.afoolishmanifesto.com/index.xml
 https://blog.ageinghacker.net/feeds/atom.xml
 https://blog.agrawals.org/feed/
-https://blog.ailon.org/feed
 https://blog.al4.co.nz/feed/
 https://blog.alanbernstein.net/index.xml
 https://blog.alb42.de/feed
@@ -1299,7 +1294,6 @@ https://blog.glowforge.com/feed/
 https://blog.gnoack.org/index.xml
 https://blog.goodstuff.im/rss.xml
 https://blog.gougousis.net/feed/
-https://blog.gouline.net/feed
 https://blog.grappling.ca/feed/
 https://blog.grayw.co.uk/rss/
 https://blog.gregbrockman.com/feed
@@ -1338,7 +1332,6 @@ https://blog.ikuamike.io/index.xml
 https://blog.imraniqbal.org/atom.xml
 https://blog.ingeniumsoftware.dev/rss/
 https://blog.inkyfool.com/feeds/posts/default
-https://blog.insightdatascience.com/feed
 https://blog.invisiblethings.org/feed.xml
 https://blog.ionelmc.ro/feeds/all.atom.xml
 https://blog.isosceles.com/rss/
@@ -1433,7 +1426,6 @@ https://blog.lawrencejones.dev/feed.xml
 https://blog.ldodds.com/feed/
 https://blog.ledeniz.de/index.xml
 https://blog.legitbs.net/feeds/posts/default
-https://blog.lelonek.me/feed
 https://blog.leonardofederico.com/feeds/posts/default
 https://blog.lewman.com/feed.xml
 https://blog.libove.org/index.xml
@@ -1562,7 +1554,6 @@ https://blog.picheta.me/rss.xml
 https://blog.piekniewski.info/feed/
 https://blog.pingoured.fr/index.php?feed/atom
 https://blog.pkh.me/rss.xml
-https://blog.plan99.net/feed
 https://blog.ploeh.dk/atom.xml
 https://blog.pnkfx.org/atom.xml
 https://blog.polyhaven.com/feed/
@@ -1586,7 +1577,6 @@ https://blog.regehr.org/feed
 https://blog.reiterate.app/feed.xml
 https://blog.reverberate.org/feed.xml
 https://blog.rfox.eu/atom.xml
-https://blog.rinatussenov.com/feed
 https://blog.rinesi.com/feed/
 https://blog.risingstack.com/feed/
 https://blog.ritekit.com/home.rss
@@ -1980,7 +1970,6 @@ https://bylr.info/index.xml
 https://byorgey.wordpress.com/feed/
 https://byparker.com/blog/atom.xml
 https://byronknoll.blogspot.com/feeds/posts/default
-https://byrslf.co/feed
 https://bytecellar.com/feed/
 https://bytepawn.com/feeds/all.atom.xml
 https://byterot.blogspot.com/feeds/posts/default
@@ -2857,7 +2846,6 @@ https://dothemath.ucsd.edu/feed/
 https://dotneteers.net/feed/
 https://doubleclix.wordpress.com/feed/
 https://doubleloop.net/feed/
-https://doublepulsar.com/feed
 https://dougallj.wordpress.com/feed/
 https://dougbeal.com/feed/
 https://dougbelshaw.com/blog/feed/
@@ -3590,7 +3578,6 @@ https://felx.me/feed.xml
 https://feministkilljoys.com/feed/
 https://femkreations.com/feed/
 https://ferd.ca/feed.rss
-https://ferdychristant.com/feed
 https://fernandocorreia.dev/index.xml
 https://fernandogros.com/feed/
 https://ferrucc.io/index.xml
@@ -3959,7 +3946,6 @@ https://gregoryhammond.ca/feed/
 https://gregoryszorc.com/blog/feed/
 https://gregraiz.com/feed.xml
 https://gregtatum.com/atom.xml
-https://gregtracy.com/feed
 https://greilmarcus.net/feed/
 https://grenouillebouillie.wordpress.com/feed/
 https://grep.be/blog/index.atom
@@ -6070,7 +6056,6 @@ https://neilzone.co.uk/feed/rss
 https://nelari.us/index.xml
 https://nelson.cloud/index.xml
 https://nelsonslog.wordpress.com/feed/
-https://nemhouse.com/feed
 https://nenadseo.com/feed/
 https://neopythonic.blogspot.com/feeds/posts/default
 https://neovintage.org/index.xml
@@ -7862,7 +7847,6 @@ https://tech.davis-hansson.com/index.xml
 https://tech.endeepak.com/atom.xml
 https://tech.gc.com/atom.xml
 https://tech.gerardbentley.com/feed.xml
-https://tech.holidayextras.com/feed
 https://tech.justeattakeaway.com/feed/
 https://tech.marksblogg.com/feeds/all.atom.xml
 https://tech.michaelaltfield.net/feed/
@@ -8402,7 +8386,6 @@ https://utf9k.net/rss.xml
 https://utkuufuk.com/atom.xml
 https://utotherescue.blogspot.com/feeds/posts/default
 https://uvicrec.blogspot.com/feeds/posts/default
-https://uxknowledgebase.com/feed
 https://v.cx/feed.xml
 https://v21.io/blog/feed.xml
 https://v5.chriskrycho.com/feed.xml
@@ -10030,7 +10013,6 @@ https://www.seamusbradley.net/index.xml
 https://www.seancdavis.com/feed.xml
 https://www.seat31b.com/feed/
 https://www.sebastianhesse.de/feed/
-https://www.secretdesihistory.com/feed
 https://www.selfcommit.com/feeds/posts/default
 https://www.semicomplete.com/index.xml
 https://www.sergiomannino.com/insights?format=rss


### PR DESCRIPTION
Like in #117 but for Medium feeds. Remove these:

https://adammcnamara.com/feed
https://aidancunniffe.com/feed
https://anee.me/feed
https://benchling.engineering/feed
https://blog.ailon.org/feed
https://blog.gouline.net/feed
https://blog.insightdatascience.com/feed
https://blog.lelonek.me/feed
https://blog.plan99.net/feed
https://blog.rinatussenov.com/feed
https://byrslf.co/feed
https://doublepulsar.com/feed
https://ferdychristant.com/feed
https://gregtracy.com/feed
https://nemhouse.com/feed
https://tech.holidayextras.com/feed
https://uxknowledgebase.com/feed
https://www.secretdesihistory.com/feed
