### PR TITLE
Fix browser back and forward buttons

### DIFF
--- a/app/sw.py
+++ b/app/sw.py
@@ -1,21 +1,15 @@
 import pickle
-import requests
 import re
 from flask import (
     Flask,
-    render_template_string,
     request,
     redirect,
-    jsonify,
-    Markup,
     render_template,
-    make_response,
     Response
 )
 import feedparser
 from dateutil.parser import parse
 from apscheduler.schedulers.background import BackgroundScheduler
-import pytz
 import random
 from datetime import datetime, timedelta, timezone
 from urllib.parse import urlparse, parse_qs
@@ -24,7 +18,7 @@ from datetime import datetime
 import os
 import time
 from urllib.parse import urlparse
-from feedwerk.atom import AtomFeed, FeedEntry
+from feedwerk.atom import AtomFeed
 
 def time_ago(timestamp):
     delta = datetime.now() - timestamp

--- a/app/templates/index.html
+++ b/app/templates/index.html
@@ -12,7 +12,7 @@
 <body>
   <div id="header">
     <div id="controls">
-      <a href="{{ prefix }}{{ query_string }}" class="stumble-link">
+      <a href="/next{{ query_string }}" class="stumble-link">
         <button>Next Post</button>
       </a>
       <div id="url-display">


### PR DESCRIPTION
> I realise that I have not co-ordinated this work in the Discord or the GitHub issues. This was a bit of an in-the-moment frustration fix that I had not planned to work on, so apologies for the drive-by contribution.

**Update**: I noticed that there is a feedback item about this at https://kagifeedback.org/d/2176-browsing-history-is-lost-on-new-post-and-refresh

## Background

I often find myself accidentily skipping past a piece of content that I am interested in and am unable to find it again without spamming the "Next Post" button until the RNG blesses me with the same content again. What I would really like is if the back/forward buttons in my browser allowed me to go back to content that I missed, or want to read again.

## Implementation

In keeping with the spirit of allowing core functionality to work without any JavaScript, I have implemented this entirely server-side using HTTP redirects. The logic in the PR is as follows:
* User hits `/` (opening small web for the first time)
* The index handler detects that there is no `url` parameter, and therefore no video to play
* User is redirected to `/next`
* The `next_item` handler picks a random piece of content using the same logic as before
* The user is redirected to `?url=$url` with a HTTP `307` response code (this seems like the correct one based on a quick check on Wikipedia?)
* The index handler pulls the content based on the `url` parameter

## Notes
1. This logic should still works for Youtube videos (that is what I use SmallWeb for the most personally)
2. I have removed the `prefix` variable from the "Next Post" button, but I assume it needs to be put back. I'm not sure what the potential values are, and so I wanted to seek code review before adding it back.