### PR TITLE
feat: Add JS to disable "Next Post" for 5 seconds

### DIFF
--- a/app/static/style.css
+++ b/app/static/style.css
@@ -308,5 +308,5 @@ svg {
   }
 
 .stumble-link button {
-    animation: enableButton 0s forwards 2s;
+    animation: enableButton 0s forwards 5s;
 }

--- a/app/templates/index.html
+++ b/app/templates/index.html
@@ -242,5 +242,16 @@ end.</p>
       <iframe src="{{url}}"></iframe>
     </div>
   {% endif %}
+
+  <script>
+    window.addEventListener("DOMContentLoaded", () => {
+      const nextPostLink = document.querySelector(".stumble-link");
+      const oldHref = nextPostLink.href;
+      nextPostLink.removeAttribute("href");
+      setTimeout(() => {
+        nextPostLink.setAttribute("href", oldHref);
+      }, 5000);
+    });
+  </script>
 </body>
 </html>


### PR DESCRIPTION
This PR adds some basic JavaScript that will disable the "Next Post" for 5 seconds after page load.

This complements the CSS change in 837af0c6b8e2fc34242f1f70184f52b4eec300bd which disables the button visually for 2 seconds, but does not stop users from pushing it. I have increased the CSS value from that patch to 5 seconds to match the JS.

Naturally this patch will work just fine if the user disables JS, but the disabled button will be purely visual.

I have added the JS to the bottom of the index.html template instead of a separate file as there is no other JS on the page, so it seems a bit silly to force the browser to make another HTTP request just for a few lines of JS.

**With JS Enabled**

https://github.com/kagisearch/smallweb/assets/3310215/e940e044-910d-47f3-bca8-8562ed976cc9

**With JS Disabled**

https://github.com/kagisearch/smallweb/assets/3310215/9f5f26e2-e8ba-4bae-b439-a543ed286ab2

