### PR TITLE
Update smallweb.txt

### DIFF
--- a/smallweb.txt
+++ b/smallweb.txt
@@ -220,6 +220,7 @@ https://aaronsadventures.blogspot.com/feeds/posts/default
 https://aaronstacy.com/atom.xml
 https://aaronstannard.com/feed.xml
 https://aaronstuyvenberg.com/feed.xml
+https://aaronweb.net/feed/
 https://aaugh.com/wordpress/feed/
 https://abandoned.photos/rss
 https://abbbi.github.io/feed.xml
@@ -4934,6 +4935,7 @@ https://juanitorduz.github.io/index.xml
 https://juanmanuelalloron.com/feed/
 https://juanuys.com/feed.xml
 https://judithcurry.com/feed/
+https://judithvanstegeren.com/blog/atom.xml
 https://juffalow.com/blog/rss.xml
 https://juhaliikala.com/feed.xml
 https://jukkaniiranen.com/feed/
@@ -6485,7 +6487,6 @@ https://otpok.com/feed/
 https://ounapuu.ee/posts/index.xml
 https://ourincrediblejourney.tumblr.com/rss
 https://out-of-cheese-error.netlify.app/feeds/all.rss.xml
-https://outflank.nl/blog/feed/
 https://outofthecomfortzone.frantzmiccoli.com/feed.xml
 https://overengineer.dev/blog/feeds/all.xml
 https://overreacted.io/rss.xml
@@ -8251,6 +8252,7 @@ https://thomasvilhena.com/feed.xml
 https://thomaswdinsmore.com/feed/
 https://thomlangford.com/feed/
 https://thompsonsed.co.uk/feed
+https://thomwiggers.nl/post/index.xml
 https://thonyc.wordpress.com/feed/
 https://thorstenball.com/atom.xml
 https://thoughtfulatlas.bearblog.dev/feed/?type=rss
@@ -9935,7 +9937,6 @@ https://www.noahlebovic.com/rss/
 https://www.noahw.org/Blog/Feed
 https://www.noise.pictures/feed.rss
 https://www.nomadicnotes.com/feed/
-https://www.noncommutativegeometry.nl/feed/
 https://www.norberhuis.nl/rss/
 https://www.notcheckmark.com/rss/
 https://www.notebookstories.com/feed/


### PR DESCRIPTION
Add judithvanstegeren.com, aaronweb.net and thomwiggers.nl

As I'm a native Dutch speaker, I checked all *.nl domains. I ended up removing two sites that violate the requirements:

- outflank.nl is a commercial blog
- noncummutativegeometry.nl's recent posts are mostly academic vacancies