### PR TITLE
Update smallweb.txt

### DIFF
--- a/smallweb.txt
+++ b/smallweb.txt
@@ -10003,7 +10003,6 @@ https://www.patjfin.com/feed.xml
 https://www.patkua.com/feed/
 https://www.patrickxchong.com/feed.xml
 https://www.pauladamsmith.com/atom.xml
-https://www.paulcraigroberts.org/feed/
 https://www.pauljmiller.com/rss.xml
 https://www.paulox.net/feed.xml
 https://www.paulsblog.dev/rss/


### PR DESCRIPTION
Remove Paul Craig Roberts feed. This website is a trove of disinformation. Articles such as:

1. The Evidence Is In: The Covid Vax Is Causing Young People to Die of Cancer at Explosive Rates
2. Disney Admits the Company Is Losing Shareholders’ Money in order to Advance A Woke Agenda of Sexual Perversion and Demonization of White People

Is this the content Kagi wants to be spreading?