### PR TITLE
Removing site promoting "great replacement theory"

### DIFF
--- a/smallweb.txt
+++ b/smallweb.txt
@@ -10046,7 +10046,6 @@ https://www.patjfin.com/feed.xml
 https://www.patkua.com/feed/
 https://www.patrickxchong.com/feed.xml
 https://www.pauladamsmith.com/atom.xml
-https://www.paulcraigroberts.org/feed/
 https://www.pauljmiller.com/rss.xml
 https://www.paulox.net/feed.xml
 https://www.paulsblog.dev/rss/


### PR DESCRIPTION
Removing https://www.paulcraigroberts.org/ due to https://www.paulcraigroberts.org/2024/01/19/american-prosperity-depends-on-a-nonwhite-future/

I believe smallweb should be diverse without promoting hateful ideologies. Cf. https://en.m.wikipedia.org/wiki/Great_Replacement