### PR TITLE
add マリウス.com

### DIFF
--- a/smallweb.txt
+++ b/smallweb.txt
@@ -10726,3 +10726,4 @@ https://zupzup.org/index.xml
 https://zverok.space/feed.xml
 https://zwclose.github.io/feed.xml
 https://zwischenzugs.com/feed
+https://マリウス.com/index.xml


### PR DESCRIPTION
Though the URL contains non-latin letters, the content is in English, which is in accordance to this rule as well:
> Content must be in English (currently, other languages are not accepted).