### PR TITLE
feat: POST-only non-idempotent endpoints

### DIFF
--- a/app/static/style.css
+++ b/app/static/style.css
@@ -29,7 +29,7 @@ body {
   align-items: center;
 }
 
-#header button, .ok-button {
+.next-button, .ok-button {
   background-color: #3498db;
   border: none;
   padding: 8px !important;
@@ -65,18 +65,38 @@ body {
   min-width:10px;
 }
 
-#header a {
+#header a, .favorite-link, .flag-link {
   color: white;
   text-decoration: none;
 }
 
-#header .middle a, #header .right a {
+.flag-danger {
+  color: red;
+}
+
+#header .middle a, #header .right a, .favorite-link, .flag-link {
   padding: 0 10px;
+}
+
+.favorite-link, .flag-link {
+  font-family: pixel, Arial, sans-serif;
+  font-size: 20px;
+  background: none;
+  border: none;
+  cursor: pointer;
+}
+
+#header .favorite-link:hover, #header .flag-link:hover {
+  background-color: transparent;
 }
 
 .middle {
   flex: 1;
   text-align: center;
+}
+
+.middle form {
+  display: inline-block;
 }
 
 .right {
@@ -194,12 +214,12 @@ body {
   text-decoration: none;
   color: #ecf0f1;
   cursor: pointer;
-  text-weight : 700
+  font-weight : 700
 }
 
 .share-option:hover {
   background-color: rgba(255, 255, 255, 0.1);
-  text-weight: 700;
+  font-weight: 700;
 }
 
 .spread-love {

--- a/app/templates/index.html
+++ b/app/templates/index.html
@@ -13,7 +13,7 @@
   <div id="header">
     <div id="controls">
       <a href="{{ prefix }}{{ query_string }}" class="stumble-link">
-        <button>Next Post</button>
+        <button class="next-button">Next Post</button>
       </a>
       <div id="url-display">
       {% if author and author != '' and author !=" " %}
@@ -31,10 +31,14 @@
     </div>
     <div class="middle">
       <input type="radio" id="close-popup" name="popup" class="popup-radio" checked>
-      <a href="{{ prefix }}favorite?url={{ url }}{{ '&' if request.query_string else '' }}{{ request.query_string.decode()|safe }}"
-      class="favorite-link">Appreciate{{ ' (' ~ favorites_count ~ ')' if favorites_count > 0 else '' }}</a>
-      <a href="{{ prefix }}flag_content?url={{ url }}{{ '&' if request.query_string else '' }}{{ request.query_string.decode()|safe }}"
-      class="favorite-link">Flag{{ ' (' ~ flag_content_count ~ ')' if flag_content_count > 0 else '' }}</a>
+      <form action="{{ prefix }}favorite?{{ request.query_string.decode()|safe }}" method="post">
+        <input type="hidden" name="url" value="{{ url }}">
+        <button type="submit" class="favorite-link">Appreciate{{ ' (' ~ favorites_count ~ ')' if favorites_count > 0 else '' }}</button>
+      </form>
+      <form action="{{ prefix }}flag_content?{{ request.query_string.decode()|safe }}" method="post">
+        <input type="hidden" name="url" value="{{ url }}">
+        <button type="submit" class="flag-link">Flag{{ ' <span class="flag-danger">('|safe ~ flag_content_count ~ ')</span>'|safe if flag_content_count > 0 else '' }}</button>
+      </form>
       <!-- Note Popup -->
       <div class="popup-container">
         <label for="note-popup" class="popup-link">{{ 'Notes' if notes_count else 'Note' }}{{ ' (' ~ notes_count ~ ')' if notes_count else '' }}</label>
@@ -45,7 +49,7 @@
               <span class="note-time">({{ timestamp|time_ago }})</span> {{ note }}
             </div>
           {% endfor %}
-          <form action="{{ prefix }}note" method="get">
+          <form action="{{ prefix }}note" method="post">
             <p style="text-align:left">Got thoughts on this post? Share them in a public note.</p>
             <textarea name="note_content" class="note-textarea"></textarea>
             <input type="hidden" name="url" value="{{ url }}" />
@@ -75,11 +79,7 @@
           target="_blank">Email</a>
           <a href="https://kagi.com/summarizer/index.html?url={{url}}" class="share-option"
           target="_blank">Universal Summarizer</a>
-          {% if is_youtube %} 
-            <a href="{{ prefix }}{{ query_string }}&url={{url}}" class="share-option" target="_blank">Link here</a> 
-         {% else %}
-            <a href="{{ prefix }}{{ query_string }}?url={{url}}" class="share-option" target="_blank">Link here</a>
-         {% endif %}
+          <a href="{{ prefix }}?url={{url}}&{{query_string}}" class="share-option" target="_blank">Link here</a>
 
 
           <label for="close-popup" class="sbutton cancel-button">Cancel</label>


### PR DESCRIPTION
- Make sure data directory exists before using it
- Fix favorites always being blank on server start
- Make /favorites, /note, /flag_content endpoints POST-only
- Fix app always writing to disk even before 60 seconds have passed
- Fix app error trying to delete nonexistent query parameters
- Fix redirects after POST action
- Color flag count when greater than 0
- Fix invalid CSS property text-weight -> font-weight
- Fix incorrect query parameter handling on Share Link
- Graceful timeout if update_all fails

Closes the following issues on kagifeedback:
- https://kagifeedback.org/d/3312-small-web-appreciate-and-flag-can-potentially-be-triggered-by-browser-page-preloading
- https://kagifeedback.org/d/3312-small-web-appreciate-and-flag-can-potentially-be-triggered-by-browser-page-preloading
- https://kagifeedback.org/d/3310-small-webs-link-here-does-not-account-for-existing-query-parameters