### PR TITLE
Removed jrogel.com

### DIFF
--- a/smallweb.txt
+++ b/smallweb.txt
@@ -4958,7 +4958,6 @@ https://jrhawley.ca/feed.xml
 https://jriddell.org/feed/
 https://jrients.blogspot.com/feeds/posts/default
 https://jrock.us/posts/index.xml
-https://jrogel.com/feed/
 https://jross.me/rss
 https://jrott.com/index.xml
 https://jrs-s.net/feed/


### PR DESCRIPTION
This PR removes jrogel.com as the articles are skeletons that link to paywalled Medium articles (see, eg, https://jrogel.com/mastering-virtual-environments/).