### PR TITLE
Remove theirrelevantinvestor.com

### DIFF
--- a/smallweb.txt
+++ b/smallweb.txt
@@ -8198,7 +8198,6 @@ https://thehousecarpenter.wordpress.com/feed/
 https://theindiebobspot.blogspot.com/feeds/posts/default
 https://theinnovationist.com/feed/
 https://theinvasionnetwork.wordpress.com/feed/
-https://theirrelevantinvestor.com/feed/
 https://thejavaguy.org/index.xml
 https://thejaymo.tumblr.com/rss
 https://thejohnfox.com/feed/


### PR DESCRIPTION
This PR removes theirrelevantinvestor.com which is a bit sparse on content (see, eg, https://theirrelevantinvestor.com/2024/02/23/the-compound-and-friends-46/).