### PR TITLE
Add OPML Generation

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -27,6 +27,8 @@ RUN chmod +x gcsfuse_run.sh
 COPY app/requirements.txt requirements.txt
 RUN pip3 install --no-cache-dir -r requirements.txt
 
+COPY smallweb.txt smallweb.txt
+
 COPY app/ .
 EXPOSE $PORT
 

--- a/README.md
+++ b/README.md
@@ -10,6 +10,8 @@ Few things to note:
 
 - You can also use the [RSS feed](https://kagi.com/api/v1/smallweb/feed) or access these results as a part of a broader [Kagi News Enrichment API](https://help.kagi.com/kagi/api/enrich.html). 
 
+- There is an [OPML file](https://kagi.com/api/v1/smallweb/opml) of the sites which make up the above RSS feed
+
 ## Criteria for posts to show on the KSW website
 
 If the blog is included in small web feed list (which means it has content in English, it is informational/educational by nature and it is not trying to sell anything) we check for these two things to show it on the site:

--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ Few things to note:
 
 - You can also use the [RSS feed](https://kagi.com/api/v1/smallweb/feed) or access these results as a part of a broader [Kagi News Enrichment API](https://help.kagi.com/kagi/api/enrich.html). 
 
-- There is an [OPML file](https://kagi.com/api/v1/smallweb/opml) of the sites which make up the above RSS feed
+- There is an [OPML file](https://kagi.com/smallweb/opml) of the sites which make up the above RSS feed
 
 ## Criteria for posts to show on the KSW website
 

--- a/app/requirements.txt
+++ b/app/requirements.txt
@@ -20,3 +20,4 @@ urllib3==2.0.7
 Werkzeug==3.0.1
 feedwerk==1.1.0
 python-dateutil
+pyopml==1.0.0

--- a/app/sw.py
+++ b/app/sw.py
@@ -25,6 +25,7 @@ import os
 import time
 from urllib.parse import urlparse
 from feedwerk.atom import AtomFeed, FeedEntry
+from opml import OpmlDocument
 
 DIR_DATA = "data"
 if not os.path.isdir(DIR_DATA):
@@ -128,6 +129,31 @@ def update_entries(url):
     else:
         return False
 
+def update_opml(get_urls=True):
+    global opml_document
+
+    print("Create OPML document")
+
+    # metadata
+    opml_document.date_created = datetime.now()
+    opml_document.title = "Kagi Smallweb Feeds"
+
+    with open("smallweb.txt") as f:
+        for url in f:
+            if get_urls:
+                feed = feedparser.parse(url)
+                desc = None
+                title = None
+                html_url = None
+                if 'description' in feed['feed']:
+                    desc = feed['feed']['description']
+                if 'title' in feed['feed']:
+                    title = feed['feed']['title']
+                if 'link' in feed['feed']:
+                    html_url = feed['feed']['link']
+                opml_document = opml_document.add_rss(url, url, title=title, description=desc, html_url=html_url, language="en_US")
+            else:
+                opml_document = opml_document.add_rss(url, url, language="en_US")
 
 def load_public_suffix_list(file_path):
     public_suffix_list = set()
@@ -362,6 +388,9 @@ def appreciated():
 
     return Response(feed.to_string(), mimetype="application/atom+xml")
 
+@app.route("/opml")
+def opml():
+    return Response(opml_document.dumps(), mimetype="text/x-opml")
 
 time_saved_favorites = datetime.now()
 time_saved_notes = datetime.now()
@@ -371,6 +400,8 @@ urls_cache = []
 urls_yt_cache = []
 
 favorites_dict = {}  # Dictionary to store favorites count
+
+opml_document = OpmlDocument()
 
 try:
     with open(PATH_FAVORITES, "rb") as file:
@@ -401,6 +432,9 @@ except:
 
 # get feeds
 update_all()
+
+# create opml document (only needs to run once)
+update_opml()
 
 # Update feeds every 1 hour
 scheduler = BackgroundScheduler()

--- a/app/templates/index.html
+++ b/app/templates/index.html
@@ -193,6 +193,8 @@
          <a
          class="share-option" target="_blank"
          href="https://kagi.com/smallweb/appreciated">Appreciated/Notable</a>
+         <a
+         class="share-option" target="_blank" href="https://kagi.com/smallweb/opml">OPML</a>
           <label for="close-popup" class="sbutton cancel-button">Cancel</label>
         </div>
       </div>


### PR DESCRIPTION
I've added code to generate an OPML file. It includes a function, `update_opml(get_urls)` in sw.py which generates an OPML file, and adds the `opml` router path. I also updated the dependencies in requirements.txt, added a link to the html template, and added a COPY line to the dockerfile for smallweb.txt.

The get_urls parameter is for whether it attempts to get feed metadata - I initially looked for a way to reuse the feed metadata that kagi already gets, but since the full feed generation is done through the kagi API, I didn't see a way to hook into that to reuse the metadata from those requests. If set to False, it instead simply puts the links into the OPML file on their own.

I hope this is sufficient - Thank you for considering including this feature.