### PR TITLE
Remove maurice-renck.de

### DIFF
--- a/smallweb.txt
+++ b/smallweb.txt
@@ -6470,7 +6470,6 @@ https://mattwalsh.dev/rss/
 https://mattwynne.net/feed/
 https://matureladyfriend.com/feed/
 https://matuzo.at/feed.xml?rev=1692261873339
-https://maurice-renck.de/de/feed.rss
 https://mauriciopina.com/feed/atom/
 https://maurizioleo.com/rss/
 https://mauromorales.com/feed/


### PR DESCRIPTION
Site is in German aside from a YouTube embed and a reblog.