### PR TITLE
Remove smallbizseo.com

### DIFF
--- a/smallweb.txt
+++ b/smallweb.txt
@@ -13432,7 +13432,6 @@ https://www.skrasser.com/feed.xml
 https://www.slashgeek.net/feed/
 https://www.sligocki.com/feed.xml
 https://www.sloww.co/feed/
-https://www.smallbizseo.com//feed/atom
 https://www.smbaker.com/feed
 https://www.smokingonabike.com/feed/
 https://www.smolways.com/blog-feed.xml


### PR DESCRIPTION
This site appears to be marketing-related, not small web.