### PR TITLE
Add hisaac.net to smallweb.txt

### DIFF
--- a/smallweb.txt
+++ b/smallweb.txt
@@ -115,6 +115,7 @@ http://feedpress.me/stephaniewalter-blog-en
 http://feeds.ellugar.co/ellugar-logs
 http://feeds.exploringbinary.com/exploringbinary
 http://feeds.feedburner.com/3till7
+http://feeds.feedburner.com/audiocookbook
 http://feeds.feedburner.com/BarbarianMeetsCoding
 http://feeds.feedburner.com/BernardoKastrup
 http://feeds.feedburner.com/Blog-WillHawkes
@@ -2659,6 +2660,7 @@ https://brendaneich.com/feed/
 https://brendanhufford.com/feed/
 https://brendastorer.com/feed.xml
 https://brennan.io/blog/rss.xml
+https://brentley.dev/atom.xml
 https://brentlogan.com/feed
 https://brentter.com/index.xml
 https://bret.dk/feed/
@@ -2694,6 +2696,7 @@ https://brianondrako.com/feed/
 https://brianreiter.org/feed/
 https://brianschrader.com/rss.xml
 https://brianstadnicki.github.io/index.xml
+https://brianstucki.com/rss/
 https://briansunter.com/index.xml
 https://briantissot.com/feed/
 https://brianturchyn.net/rss/
@@ -2793,7 +2796,7 @@ https://buttondown.email/meticulous.serendipity/rss
 https://buzzert.net/feed.xml
 https://buzzmachine.com/feed/
 https://bvckup2.com/wip/rss
-https://bvisness.me/index.xml	
+https://bvisness.me/index.xml
 https://bwtas.blogspot.com/feeds/posts/default
 https://bxt.rs/index.xml
 https://bylr.info/index.xml

--- a/smallweb.txt
+++ b/smallweb.txt
@@ -5595,6 +5595,7 @@ https://hiphopisntdead.blogspot.com/feeds/posts/default
 https://hiran.in//feed.xml
 https://hireliz.com/feed/
 https://hirrolot.github.io/rss.xml
+https://hisaac.net/feed.xml
 https://hisham.hm/feed/atom/
 https://historicallywoman.wordpress.com/feed/
 https://historicalragbag.com/feed/


### PR DESCRIPTION
This adds my personal website, [hisaac.net](https://hisaac.net) to the smallweb.txt list.

I've also added a few other sites:

- audiocookbook.org (http://feeds.feedburner.com/audiocookbook)
- brentley.dev (https://brentley.dev/atom.xml)
- brianstucky.com (https://brianstucki.com/rss/)