### PR TITLE
remove css-tricks-com

### DIFF
--- a/smallweb.txt
+++ b/smallweb.txt
@@ -3425,7 +3425,6 @@ https://cs007.blog/feed/
 https://cskwrd.github.io/atom.xml
 https://csorianognome.wordpress.com/feed/
 https://css-irl.info/rss.xml
-https://css-tricks.com/feed/
 https://css.oddbird.net/feed.xml
 https://cstheory-events.org/feed/
 https://ctoomey.com/atom.xml


### PR DESCRIPTION
They are neither a personal blog (a team of multiple part-time writers, as well as guests) and have been acquired by DigitalOcean in 2021. See https://css-tricks.com/thank-you-2024-edition/