### PR TITLE
Preserve dates in appreciated feed

### DIFF
--- a/app/sw.py
+++ b/app/sw.py
@@ -199,10 +199,10 @@ def index():
 
     if search_query.strip():  # Only perform search if query is not empty or just whitespace
         cache = [
-            if search_query in url.lower() or 
-            any(search_query.lower() == word.lower() for word in title.split()) or 
-            any(search_query.lower() == word.lower() for word in author.split()) or 
             (url, title, author, description, _date) for url, title, author, description in cache
+            if search_query in url.lower() or
+            any(search_query.lower() == word.lower() for word in title.split()) or
+            any(search_query.lower() == word.lower() for word in author.split()) or
             any(search_query.lower() == word.lower() for word in description.split())
         ]
         if not cache:

--- a/app/sw.py
+++ b/app/sw.py
@@ -1,21 +1,15 @@
 import pickle
-import requests
 import re
 from flask import (
     Flask,
-    render_template_string,
     request,
     redirect,
-    jsonify,
     render_template,
-    make_response,
     Response,
 )
 import feedparser
 import feedparser
-from dateutil.parser import parse
 from apscheduler.schedulers.background import BackgroundScheduler
-import pytz
 import random
 from datetime import datetime, timedelta, timezone
 from urllib.parse import urlparse, parse_qs
@@ -24,7 +18,7 @@ from datetime import datetime
 import os
 import time
 from urllib.parse import urlparse
-from feedwerk.atom import AtomFeed, FeedEntry
+from feedwerk.atom import AtomFeed
 
 appreciated_feed = None  # Initialize the variable to store the appreciated Atom feed
 

--- a/app/sw.py
+++ b/app/sw.py
@@ -11,10 +11,9 @@ import feedparser
 import feedparser
 from apscheduler.schedulers.background import BackgroundScheduler
 import random
-from datetime import datetime, timedelta, timezone
+from datetime import datetime
 from urllib.parse import urlparse, parse_qs
 import atexit
-from datetime import datetime
 import os
 import time
 from urllib.parse import urlparse
@@ -115,21 +114,6 @@ def update_all():
         print("something went wrong during update_all")
     finally:
         print("end update_all")
-
-
-def parse_date(date_string):
-    # Manually parse the date string to handle the timezone offset
-    date_format = "%a, %d %b %Y %H:%M:%S"
-    date, offset_string = date_string.rsplit(" ", 1)
-    offset_hours = int(offset_string[:-2])
-    offset_minutes = int(offset_string[-2:])
-    offset = timedelta(hours=offset_hours, minutes=offset_minutes)
-    parsed_date = datetime.strptime(date, date_format)
-    if offset_hours > 0:
-        parsed_date -= offset
-    else:
-        parsed_date += offset
-    return parsed_date.replace(tzinfo=timezone.utc)
 
 
 def update_entries(url):

--- a/app/sw.py
+++ b/app/sw.py
@@ -125,13 +125,13 @@ def update_entries(url):
         for entry in entries:
             domain = entry.link.split("//")[-1].split("/")[0]
             domain = domain.replace("www.", "")
-            updated = entry.get("updated_parsed", entry.get("published_parsed"))
-            if updated:
+            updated = datetime.utcnow()
+            updated_time = entry.get("updated_parsed", entry.get("published_parsed"))
+            if updated_time:
                 try:
-                    updated = datetime.fromtimestamp(time.mktime(updated))
+                    updated = datetime.fromtimestamp(time.mktime(updated_time))
                 except Exception:
                     pass
-            updated = updated or datetime.utcnow()
 
             formatted_entries.append(
                 {


### PR DESCRIPTION
This adds an extra date field to the url cache entries and uses it as the updated date of the appreciated feed. The date is taken from the updated or published date from the source feed when present and defaults to utcnow (as done before) if note.

fixes #345 