### PR TITLE
Add blogrolls sourced from Mastodon

### DIFF
--- a/smallweb.txt
+++ b/smallweb.txt
@@ -6268,6 +6268,7 @@ https://jemma.dev/blog/published.xml
 https://jenkuo.com/feed/
 https://jenniferlawler.com/feed/
 https://jennifermillsnews.tumblr.com/rss
+https://jenniferplusplus.com/rss/
 https://jens.mooseyard.com/index.xml
 https://jenson.org/feed/
 https://jeradhill.com/feed/
@@ -6804,6 +6805,7 @@ https://kelvinpaschal.com/rss/
 https://ken.arneson.name/feed/atom/
 https://ken.fyi/feed.rss
 https://kenan7.com/rss.xml
+https://kence.org/feed/
 https://kenhv.com/feed.xml
 https://keningzhu.com/journal?format=rss
 https://kenkantzer.com/feed/
@@ -10361,6 +10363,7 @@ https://slinkp.com/feeds/all.atom.xml
 https://slinkp.com/feeds/all.rss.xml
 https://sloopie72.wordpress.com/feed/
 https://slopwatch.com/atom.xml
+https://slothrop.org/index.xml
 https://slott-softwarearchitect.blogspot.com/feeds/posts/default
 https://slow-thoughts.com/feed/
 https://slyflourish.com/index.xml
@@ -11278,6 +11281,7 @@ https://tinyprojects.dev/feed.xml
 https://tinyshopww.blogspot.com/feeds/posts/default
 https://tipswatch.com/feed/
 https://tirkarthi.github.io/feed.xml
+https://tisiphone.net/feed/
 https://tiuraniemi.org/feed.atom
 https://tiv.today/feed.rss
 https://tj.ie/index.xml
@@ -11926,6 +11930,7 @@ https://write.as/davepolaschek/feed/
 https://write.as/enbyspaceperson/feed/
 https://write.as/hobbsc/feed/
 https://write.as/matt/feed/
+https://write.as/robdaemon/feed/
 https://write.as/thenewoil/feed/
 https://write.as/ulrikehahn/feed/
 https://write.as/zampano/feed/
@@ -12567,6 +12572,7 @@ https://www.disk91.com/feed/
 https://www.djbender.com/feed
 https://www.djmannion.net/feed.rss
 https://www.djpeacher.com/posts/index.xml
+https://www.djw.fyi/index.xml
 https://www.dmitry-ishkov.com/feeds/posts/default
 https://www.doctormonk.com/feeds/posts/default
 https://www.dodgycoder.net/feeds/posts/default
@@ -12899,6 +12905,7 @@ https://www.hscott.net/feed/
 https://www.htmhell.dev/feed.xml
 https://www.hughrawlinson.me/posts/rss.xml
 https://www.hughrundle.net/rss.xml
+https://www.humancode.us/feed/
 https://www.humprog.org/%7Estephen/blog/index.rss
 https://www.huy.dev/rss.xml
 https://www.huy.rocks/rss.xml


### PR DESCRIPTION
Adds more blogs to `smallweb.txt` sourced from my Mastodon community. All blog owners consented for their blogs to be added.

Disclaimer: `kence.org` is my own personal blog.