### PR TITLE
Add another Mastodon-sourced blog

### DIFF
--- a/smallweb.txt
+++ b/smallweb.txt
@@ -14156,6 +14156,7 @@ https://www.schakko.de/feed/
 https://www.schliefkevision.com/feed/
 https://www.schneems.com/feed.xml
 https://www.schneier.com/feed/atom
+https://www.schrag.ca/feed.xml
 https://www.sciencebase.com/science-blog/feed
 https://www.scientopia.org/feed/
 https://www.scopeofwork.net/rss/


### PR DESCRIPTION
This is a blog whose owner wasn't ready when I submitted 8fb970a4b and is now. This is not my blog (which is already in the list).