### PR TITLE
Remove parked domain

### DIFF
--- a/smallweb.txt
+++ b/smallweb.txt
@@ -5363,7 +5363,6 @@ https://gabebw.com/feed.xml
 https://gabeortiz.net/index.xml
 https://gabnotes.org/rss/
 https://gabrieldunne.com/feed.xml
-https://gabrielsieben.tech/feed/
 https://gabz.blog/posts_feed
 https://gael-varoquaux.info/feeds/all.atom.xml
 https://gaganpreet.in/index.xml


### PR DESCRIPTION
This URL currently sends you to some domain parking landing page. The feed is gone.