### PR TITLE
Remove unresolvable domains

### DIFF
--- a/smallweb.txt
+++ b/smallweb.txt
@@ -276,7 +276,6 @@ http://notes.secretsauce.net/index.xml
 http://nshipster.com/feed.xml
 http://number-none.com/blow/blog/feed.xml
 http://oceanicwilderness.com/feed/
-http://old.starbreaker.org/feeds/everything.xml
 http://onsmalltalk.com/seaside/atomFeed
 http://onsmalltalk.com/seaside/rssFeed
 http://pascal.hansotten.com/feed/
@@ -405,7 +404,6 @@ http://www.dcscience.net/feed/
 http://www.drmichaeljoyner.com/feed/
 http://www.drusepth.com/feed/
 http://www.emilio.ferrara.name/feed/
-http://www.erginsatir.com/feed/
 http://www.erinmhartshorn.com/feed/
 http://www.flutterby.net/Category:Dan_Lyke_life.rss
 http://www.fwrarejazzvinylcollector.com/blog?format=rss
@@ -698,7 +696,6 @@ https://adnanthekhan.com/feed/
 https://adol.pw/index.xml
 https://adrian.schoenig.me/feed.xml
 https://adrian3.com/rss.xml
-https://adrianbeaumont.net/feed/
 https://adrianchadd.blogspot.com/feeds/posts/default
 https://adrianhoward.com/feed.xml
 https://adrianmejia.com/atom.xml
@@ -868,7 +865,6 @@ https://alexey.radul.name/feed.xml
 https://alexeystar.com/blog/index.xml
 https://alexeyzabelin.com/rss.xml/
 https://alexgaynor.net/feed.xml
-https://alexgolec.dev/rss/
 https://alexharri.com/rss.xml
 https://alexisjanvier.net/index.xml
 https://alexjgustafson.blog/feed/
@@ -897,7 +893,6 @@ https://alexturek.com/feed.xml
 https://alexwilson.tech/feed.xml
 https://alexwlchan.net/atom.xml
 https://alexwlchan.net/til/atom.xml
-https://alexy.tech/rss.xml
 https://alfarchives.wordpress.com/feed/
 https://alfiecg.uk/feed.xml
 https://alfy.blog/feed.xml
@@ -1684,7 +1679,6 @@ https://binal.pub/index.xml
 https://binarybonsai.com/blog?format=rss
 https://binarydebt.wordpress.com/feed/
 https://binarydigit.city/feed
-https://binaryho.me/rss/
 https://binarysolo.blog/feed.xml
 https://binocularshot.tumblr.com/rss
 https://binovarghese.com/index.xml
@@ -1764,7 +1758,6 @@ https://blog.aaronkharris.com/posts.atom
 https://blog.abctaylor.com/feed/
 https://blog.abluestar.com/feed.xml
 https://blog.academicbiz.com/atom.xml
-https://blog.acolyer.org/feed/
 https://blog.adambell.ca/feed.xml
 https://blog.adambell.ca/rss.xml
 https://blog.adamchalmers.com/atom.xml
@@ -2092,7 +2085,6 @@ https://blog.helloruby.com/rss
 https://blog.henricook.com/rss.xml
 https://blog.herlein.com/index.xml
 https://blog.hiler.eu/feed.xml
-https://blog.hirob.in/feed.xml
 https://blog.hnnng.space/feed/
 https://blog.honzamrazek.cz/feed/
 https://blog.horner.tj/rss/
@@ -2140,7 +2132,6 @@ https://blog.jessfraz.com/index.xml
 https://blog.jessriedel.com/feed/
 https://blog.jetbrains.com/go/feed/
 https://blog.jethro.dev/index.xml
-https://blog.jeujeus.de/feed/feed.xml
 https://blog.jez.io/atom.xml
 https://blog.jfedor.org/feeds/posts/default
 https://blog.jfo.click/feed.xml
@@ -2327,11 +2318,9 @@ https://blog.nelhage.com/atom.xml
 https://blog.nem.ec/feed.xml
 https://blog.nemausat.com/rss.xml
 https://blog.nephics.se/rss.xml
-https://blog.ner3y.me/feed/
 https://blog.networkprofile.org/rss/
 https://blog.nfld.uk/feed/
 https://blog.nick.burns.io/feed.xml
-https://blog.nightfox.tech/feed
 https://blog.nil.im/atom
 https://blog.nilbus.com/feed.xml
 https://blog.nilenso.com/atom.xml
@@ -2432,10 +2421,8 @@ https://blog.rinesi.com/feed/
 https://blog.ritekit.com/home.rss
 https://blog.rnstlr.ch/feeds/all.atom.xml
 https://blog.roastidio.us/feed.xml
-https://blog.roastmylandingpage.com/rss/
 https://blog.robbowley.net/feed/
 https://blog.robenkleene.com/feed/atom/
-https://blog.robertsimoes.org/index.xml
 https://blog.robsayers.com/feed/
 https://blog.roguetemple.com/feed/
 https://blog.rom1v.com/feed/
@@ -2526,7 +2513,6 @@ https://blog.superautomation.co.uk/feeds/posts/default
 https://blog.supertuxkart.net/feeds/posts/default
 https://blog.svenpeter.dev/index.xml
 https://blog.svgames.pl/rss.xml
-https://blog.swierczynski.net/feed.xml
 https://blog.sylver.dev/rss.xml
 https://blog.syntaxseed.com/feed/
 https://blog.systemed.net/rss
@@ -2559,7 +2545,6 @@ https://blog.thibaut-rousseau.com/atom.xml
 https://blog.tho.ms/feed.xml
 https://blog.thomashampel.com/blog/tomcat2000.nsf/content.rss
 https://blog.thomaspuppe.de/feed/atom
-https://blog.tiagorangel.com/rss.xml
 https://blog.timac.org/index.xml
 https://blog.timo.page/feed.xml
 https://blog.timowens.io/rss/
@@ -2656,7 +2641,6 @@ https://blog.zdsmith.com/feed.xml
 https://blog.zedas.fr/index.xml
 https://blog.zerolimits.dev/feed.rss
 https://blog.zfeldman.com/feed/
-https://blog.zioibi.com/feed.xml
 https://blog.znote.io/rss.xml
 https://blog.zorinaq.com/feed-rss.xml
 https://blog.zsec.uk/rss/
@@ -2913,7 +2897,6 @@ https://bsdly.blogspot.com/feeds/posts/default
 https://bsdpunk.blogspot.com/feeds/posts/default
 https://bsless.github.io/feed.xml
 https://bszyman.com/feeds/all.atom.xml
-https://bt.ht/atom.xml
 https://btburnett.com/feed
 https://btorpey.github.io/atom.xml
 https://btrussell-fishingthroughlife.blogspot.com/feeds/posts/default
@@ -3015,7 +2998,6 @@ https://calvincorreli.com/blog.xml
 https://calvinrosser.com/feed/
 https://camdez.com/index.xml
 https://camendesign.com/rss
-https://cameracode.coffee/feed/
 https://cameroncounts.wordpress.com/feed/
 https://cameronpavey.me/rss/feed.xml
 https://camhashemi.com/index.xml
@@ -3431,7 +3413,6 @@ https://cohan.dev/index.xml
 https://coin-coin.xyz/atom.xml
 https://colatkinson.site/feed.xml
 https://cole007.net/feed.rss
-https://coleb.blog/posts_feed
 https://colin-macleod.blogspot.com/feeds/posts/default
 https://colincogle.name/blog/atom.xml
 https://colinhacks.com/rss.xml
@@ -4128,7 +4109,6 @@ https://dmoren.com/feed/
 https://dmrthesis.net/feed/
 https://dmrz.dev/index.xml
 https://dmtopolog.com/feed.xml
-https://dmuhs.blog/feed/
 https://dnikub.dev/feed.xml
 https://dnlytras.com/rss.xml
 https://dnovatchev.wordpress.com/feed/
@@ -4517,7 +4497,6 @@ https://eric-pierce.com/index.xml
 https://eric.jain.name/atom.xml
 https://eric.mann.blog/feed/
 https://ericadrayton.com/feed/
-https://ericasadun.com/feed/
 https://ericbeaty.com/feed/
 https://ericdaigle.ca/atom.xml
 https://ericekholm.com/blog.xml
@@ -5209,7 +5188,6 @@ https://flyingsinger.blogspot.com/feeds/posts/default
 https://fmjansen.com/feed.xml
 https://fnordig.de/feed.xml
 https://focustivity.blog/feed/feed.xml
-https://fodor.org/feed.xml
 https://foeppel.com/feed/
 https://fogblog-hermansheephouse.blogspot.com/feeds/posts/default
 https://fogknife.com/atom.xml
@@ -5277,7 +5255,6 @@ https://franklin.dyer.me/rss/en
 https://frankmeeuwsen.com/feed.xml
 https://frankrenold.ch/index.xml
 https://frankwiles.com/posts/index.xml
-https://frankz.hu/rss/
 https://frankzliu.com/feed.xml
 https://frantic.im/feed.xml
 https://franziflows.de/feed/
@@ -5478,7 +5455,6 @@ https://gilkalai.wordpress.com/feed/
 https://gill.net.in/index.xml
 https://gilmi.me/blog/atom.xml
 https://gils-blog.tayar.org/feed/feed.xml
-https://ginevrakirkland.blog/rss
 https://ginger.wtf/feed.xml
 https://gingerjumble.wordpress.com/feed/
 https://ginglis.me/feed.xml
@@ -5624,7 +5600,6 @@ https://grodog.blogspot.com/feeds/posts/default
 https://grokinfullness.blogspot.com/feeds/posts/default
 https://grossack.site/feed.xml
 https://grosser.it/feed/
-https://groundedsage.dev/feed/feed.xml
 https://groverlab.org/feed.xml
 https://groveronline.com/feed/
 https://growinguptransgender.com/feed/
@@ -5964,7 +5939,6 @@ https://hydn.dev/rss/
 https://hyegar.com/index.xml
 https://hynek.me/index.xml
 https://hypecycles.com/feed/
-https://hyper.dev/all.rss.xml
 https://hyperborea.org/journal/feed/
 https://hypercritical.co/feeds/main
 https://hyperparameter.space/index.xml
@@ -6184,7 +6158,6 @@ https://itsallgreektoanna.wordpress.com/feed/
 https://itsbeenawhile.the-comic.org/rss/
 https://itsjustdj.com/feed/
 https://itskristin.bearblog.dev/feed
-https://itsourhollywood.blog/feed/
 https://itstartswithabirthstone.blogspot.com/feeds/posts/default
 https://itsthebageler.com/feed/
 https://ittavern.com/rss.xml
@@ -6392,7 +6365,6 @@ https://javier.io/atom.xml
 https://javiergarmon.com/rss/
 https://javvadmalik.com/feed/
 https://jawher.me/index.xml
-https://jawn.net/rss/
 https://jay.jvf.cc/index.xml
 https://jayakody2000lk.blogspot.com/feeds/posts/default
 https://jaycarlson.net/feed/
@@ -6488,7 +6460,6 @@ https://jeroenjanssens.com/feed.xml
 https://jeroenpelgrims.com/atom.xml
 https://jeroensangers.com/feed.xml
 https://jeromesalimao.com/rss.xml
-https://jeromysonne.com/feed/
 https://jerrygamblin.com/feed/
 https://jerryjones.dev/feed/
 https://jerrynsh.com/rss/
@@ -6810,7 +6781,6 @@ https://jpmartin.com/feed/
 https://jpmens.net/atom.xml
 https://jpminda.com/feed/
 https://jpreston.xyz/feed.xml
-https://jqpublicblog.com/feed/
 https://jqwhitcomb.com/feed
 https://jrasm.com/rss/
 https://jrburke.com/atom.xml
@@ -8200,12 +8170,10 @@ https://michalkolacek.xyz//feed.xml
 https://michalzuber.wordpress.com/feed/
 https://michele.io/index.xml
 https://michelfiffe.com/?feed=rss2
-https://micro.publish/feed/
 https://micro.thomasbaart.nl/feed/
 https://micro.webology.dev/feed.xml
 https://micro.welltempered.net/feed.xml
 https://microblog.ahti.space/nortti/no-shares.xml
-https://microblog.pratikmhatre.com/feed.xml
 https://microcorelabs.wordpress.com/feed/
 https://microkerneldude.org/feed/
 https://microkhan.com/feed/
@@ -8579,7 +8547,6 @@ https://nakabonne.dev/index.xml
 https://nalaginrut.com/feed/atom
 https://nalanj.dev/index.xml
 https://nalexn.github.io/feed.xml
-https://namc.in/index.xml
 https://namerology.com/feed/
 https://nami.land/feed.xml
 https://nancyfriedman.typepad.com/away_with_words/atom.xml
@@ -8846,7 +8813,6 @@ https://noeldemartin.com/blog/rss.xml
 https://noeldemartin.com/now/rss.xml
 https://noelwelsh.com/atom.xml
 https://noescapevg.com/feed/
-https://nofacedjuju.co.uk/feed/
 https://noidea.dog/blog?format=rss
 https://noisydeadlines.net/feed/
 https://noisydecentgraphics.typepad.com/design/atom.xml
@@ -8880,7 +8846,6 @@ https://norvig.com/rss-feed.xml
 https://nostodnayr.net/feeds/rss
 https://nosuchthingasbadweather.blogspot.com/feeds/posts/default
 https://not-matthias.github.io/atom.xml
-https://not2grand.co.uk/feed/
 https://notacoder.fyi/feed.atom
 https://notawfulandboring.blogspot.com/feeds/posts/default
 https://notebook.drmaciver.com/feed.xml
@@ -9498,7 +9463,6 @@ https://polymath.net/rss/
 https://polymathprojects.org/feed/
 https://polytechnic.co.uk/blog/rss/
 https://pomb.us/rss.xml
-https://ponadr.blog/feed/
 https://poolp.org/index.xml
 https://poor.dev/index.xml
 https://popcar.bearblog.dev/feed/?type=rss
@@ -9637,10 +9601,8 @@ https://pulpcovers.com/feed/
 https://pulsar17.me/feed/index.xml
 https://punkeinfilm.blogspot.com/feeds/posts/default
 https://punkrockor.com/feed/
-https://punkwasp.leprd.space/updatefeed.php
 https://punyamishra.com/feed/
 https://purde.net/feed/
-https://purefun.dev/posts/index.xml
 https://purplehoisin.com/feed/
 https://purpleidea.com/blog/index.xml
 https://purpleram.xyz/feed/
@@ -10366,7 +10328,6 @@ https://schmud.de/feed.rss
 https://schneems.com/feed.xml
 https://scholars-stage.org/feed/
 https://schollz.com/index.xml
-https://scholz.ruhr/feed.atom
 https://schpet.com/feed.xml
 https://schroer.ca/atom.xml
 https://science-memo.blogspot.com/feeds/posts/default
@@ -10944,7 +10905,6 @@ https://staydecent.ca/feed/
 https://staysaasy.com/feed.xml
 https://stderr.nl/index.rss
 https://steamthing.com/feed
-https://stedman.dev/atom.xml
 https://steele.blue/feed
 https://steelonsand.blogspot.com/feeds/posts/default
 https://steelthistles.blogspot.com/feeds/posts/default
@@ -11056,7 +11016,6 @@ https://studiofreya.org/index.xml
 https://studywolf.wordpress.com/feed/
 https://stuebinm.eu/rss.xml
 https://stuff.tamius.net/sacred-texts/feed/
-https://stuffnobodycaresabout.com/feed/
 https://stumblingandmumbling.typepad.com/stumbling_and_mumbling/atom.xml
 https://stuvel.eu/index.xml
 https://styledeficit.tumblr.com/rss
@@ -11390,7 +11349,6 @@ https://theexceptioncatcher.com/blog/feed.xml
 https://thefamilymuseum.co.uk/feed/
 https://thefifthwave.wordpress.com/feed/
 https://thefigureinquestion.com/feed/
-https://thefiringneuron.com/feed/
 https://thefloatingcontinent.com/rss.xml
 https://thefoggiest.dev/feed
 https://thefoggiest.dev/feed/
@@ -11615,7 +11573,6 @@ https://tia.mat.br/posts/rss.xml
 https://tianglim.net/wp/feed/
 https://tiao.io/index.xml
 https://tiberriver256.github.io/feed.xml
-https://tibortot.com/rss/
 https://tiendil.org/en/feeds/atom
 https://tig.pt/rss/
 https://tigeroakes.com/posts/rss.xml
@@ -12366,7 +12323,6 @@ https://write.as/robdaemon/feed/
 https://write.as/thenewoil/feed/
 https://write.as/ulrikehahn/feed/
 https://write.as/zampano/feed/
-https://write.emacsen.net/feed/
 https://write.hamster.dance/feed/
 https://write.kirigin.com/posts.atom
 https://writerbeware.blog/feed/
@@ -12377,7 +12333,6 @@ https://writing.natwelch.com/feed.rss
 https://writingatlarge.com/feed/
 https://writingball.blogspot.com/feeds/posts/default
 https://writingjavascript.com/rss.xml
-https://writingontablets.com/atom.xml
 https://writings.stephenwolfram.com/feed/
 https://wsbj.com/sorabji/feed
 https://wts.dev/feed.xml
@@ -12650,7 +12605,6 @@ https://www.bentasker.co.uk/rss.xml
 https://www.bentaylor.co.uk/feed.xml
 https://www.bentilden.com/feed.rss
 https://www.bergnet.org/atom.xml
-https://www.berkhanberkdemir.com/index.xml
 https://www.berrange.com/feed/
 https://www.bethanybutzer.com/blog?format=rss
 https://www.beust.com/weblog/feed/
@@ -12708,7 +12662,6 @@ https://www.blogger.com/feeds/7303400454979750101/posts/default
 https://www.blogger.com/feeds/8378574/posts/default
 https://www.blogger.com/feeds/8591474299777249503/posts/default
 https://www.blogofholding.com/?feed=rss2
-https://www.bloguslibrus.fr/atom.xml
 https://www.bluxte.net/rss.xml
 https://www.bnikolic.co.uk/blog/blog.atom
 https://www.bobbydurrettdba.com/feed/
@@ -12986,7 +12939,6 @@ https://www.decarpentier.nl/feed
 https://www.dedoimedo.com/rss_feed.xml
 https://www.deepsouthventures.com/feed/
 https://www.deeptikannapan.com/feed/
-https://www.defmacro.org/feed.xml
 https://www.depesz.com/feed/
 https://www.depthfirstlearning.com/feed.xml
 https://www.derekseaman.com/feed
@@ -13008,7 +12960,6 @@ https://www.dgendill.com/rss.xml
 https://www.dgsiegel.net/rss
 https://www.dgt.is/feed/feed.xml
 https://www.dhanjani.com/atom.xml
-https://www.dhavalvyas.me/feed.xml
 https://www.die-welt.net/rss.xml
 https://www.diegofreijo.com/index.xml
 https://www.dirtyfeed.org/feed/
@@ -13051,7 +13002,6 @@ https://www.dusterwald.com/feed/
 https://www.dutchosintguy.com/blog-feed.xml
 https://www.dylanpaulus.com/rss.xml
 https://www.dzombak.com/atom.xml
-https://www.eadan.net/index.xml
 https://www.eamoncaddigan.net/posts/index.xml
 https://www.earth.li/~noodles/blog/feed.xml
 https://www.earth.org.uk/sitemap.atom
@@ -13374,7 +13324,6 @@ https://www.ianfeather.co.uk/feed.xml
 https://www.ianhogarth.com/blog?format=rss
 https://www.iannaccone.org/feed/
 https://www.ianvisits.co.uk/articles/feed/
-https://www.icefireair.com/feed/
 https://www.icemoonprison.com/blog/feed
 https://www.idealmedicalcare.org/feed/
 https://www.idkwhojamesis.com/rss.xml
@@ -14539,7 +14488,6 @@ https://www.syntorial.com/feed/
 https://www.tabsoverspaces.com/feed.xml
 https://www.taisukemino.com/atom.xml
 https://www.taiwanquest.com/rss/
-https://www.talentcanary.com/feeds/posts/default
 https://www.talhoffman.com/atom.xml
 https://www.talkingquickly.co.uk/rss.xml
 https://www.talospace.com/feeds/posts/default
@@ -14615,7 +14563,6 @@ https://www.thenickmay.com/feed.xml
 https://www.thenordickitchen.com/feed/
 https://www.theoinglis.co.uk/rss
 https://www.thephysicsmill.com/feed/
-https://www.thepmcareer.com/feed.xml
 https://www.thepolyglotdeveloper.com/blog/index.xml
 https://www.thepublicdomain.org/feed/
 https://www.theremake.org/rss/
@@ -14871,7 +14818,6 @@ https://www.zverovich.net/atom.xml
 https://www.zylstra.org/blog/feed/
 https://www.zypper.net/feed?type=rss
 https://wyattbaldwin.com/posts/rss.xml
-https://wyhaines.io/rss.xml
 https://wyrdbritain.blogspot.com/feeds/posts/default
 https://x61.sh/log/rss.xml
 https://x86.lol/feed.xml
@@ -14965,7 +14911,6 @@ https://yourdigitalaid.com/feed/
 https://yourradiance.blogspot.com/feeds/posts/default
 https://yozy.net/feed.xml
 https://yrheartout.blogspot.com/feeds/posts/default
-https://ysamm.com/?feed=rss2
 https://yuanchuan.dev/feed.xml
 https://yuanming.taichi.graphics/index.xml
 https://yudkowsky.tumblr.com/rss


### PR DESCRIPTION
These domains currently can't be resolved. Besides using my regular DNS I also checked these domains against several other DNS servers[^1] and none of them could resolve them.

It's likely that the owners let these domains expire. I'm just not 100% sure how you want to handle such cases - if you want to remove them or keep them 'just in case'. So feel free to merge or close this pull request as you see fit.


[^1]: I used https://dnschecker.org as the first best thing I could find. This site checks against various big DNS providers like Google, Cloudflare, Quad9 and many more