### PR TITLE
Add technology-related blogs

### DIFF
--- a/smallweb.txt
+++ b/smallweb.txt
@@ -11400,6 +11400,7 @@ https://thelittleengineerthatcould.blogspot.com/feeds/posts/default
 https://thelocalyarn.com/feed/
 https://thelondondead.blogspot.com/feeds/posts/default
 https://thelostbyway.com/feed
+https://theluddite.org/feed.rss
 https://them0vieblog.com/feed/
 https://themachineplanet.wordpress.com/feed/
 https://themaister.net/blog/feed/
@@ -11913,6 +11914,7 @@ https://unconj.ca/blog/atom.xml
 https://undercoverlocal.wordpress.com/feed/
 https://underhill-lounge.flannestad.com/feed/
 https://underjord.io/feed.xml
+https://underlap.org/feed/
 https://understandlegacycode.com/rss.xml
 https://undina.com/feed/
 https://undocumentedmatlab.com/feed
@@ -12637,6 +12639,7 @@ https://www.birdchick.com/blog?format=rss
 https://www.birdsoutsidemywindow.org/feed/
 https://www.bitbyte.blog/feed.xml
 https://www.bitnative.com/feed/
+https://www.bitoff.org/feed.xml
 https://www.bitquabit.com/index.xml
 https://www.bitsaboutmoney.com/archive/rss/
 https://www.bitsgalore.org/atom.xml

--- a/smallweb.txt
+++ b/smallweb.txt
@@ -8644,6 +8644,7 @@ https://nerdygirl.com/feed/
 https://nervuri.net/feed.atom
 https://nesbitt.io/feed.xml
 https://nestenius.se/feed/
+https://netapinotes.com/rss/
 https://netigen.com/rss
 https://netlicensing.io/feed.xml
 https://netninja.com/feed/

--- a/smallweb.txt
+++ b/smallweb.txt
@@ -12180,6 +12180,7 @@ https://wdkwwdk.com/atom.xml
 https://wearecult.rocks/feed
 https://wearethemutants.com/feed/
 https://weatherwest.com/feed
+https://web3.0sleptwithmywife.com/feed/
 https://web-in-security.blogspot.com/feeds/posts/default
 https://web.navan.dev/feed.rss
 https://web.tecnico.ulisboa.pt/~ist189623/wordpress/feed/


### PR DESCRIPTION
Added the following blogs, mostly technology-related:

- https://theluddite.org/
- https://underlap.org/
- https://web3.0sleptwithmywife.com/
- https://netapinotes.com/
- https://www.bitoff.org/ – this one's mine

Let me know if any of these doesn't fit the criteria of personal blog (I'm a little bit unsure about Net API Notes in particular) and I will drop it from this PR.