### PR TITLE
Remove dead feeds

### DIFF
--- a/smallweb.txt
+++ b/smallweb.txt
@@ -4535,7 +4535,6 @@ https://erikmeyersson.com/feed/
 https://erikrunyon.com/feed.xml
 https://erikschluntz.com/feed.xml
 https://eriktwice.com/en/feed/
-https://erindcole.com/feed/
 https://erinfulmer.com/feed/
 https://erinkissane.com/feed.rss
 https://erinshaw.blog/feed/

--- a/smallweb.txt
+++ b/smallweb.txt
@@ -11423,7 +11423,6 @@ https://thejpster.org.uk/atom.xml
 https://thekeesh.com/feed/
 https://thelastdrivein.com/feed/
 https://thelastpointer.github.io/index.xml
-https://thelawdogfiles.com/feed
 https://thelazylog.com/rss/
 https://thelazysre.com/atom.xml
 https://thelethaltext.me/feed/?swcfpc=1
@@ -13210,7 +13209,6 @@ https://www.fromthemurkydepths.co.uk/feed/
 https://www.frontendundefined.com/feed/feed.xml
 https://www.froyok.fr/rss.xml
 https://www.frrandp.com/feeds/posts/default
-https://www.frugalityandfreedom.com/feed/atom/
 https://www.ft.io/blog/feed.xml
 https://www.fullmoonfiberart.com/feed/
 https://www.fullstackruby.dev/feed.xml
@@ -13226,7 +13224,6 @@ https://www.fuzzygrim.com/feed.xml
 https://www.fyears.org/atom.xml
 https://www.g1a55er.net/feed.xml
 https://www.galacticbeyond.com/rss/
-https://www.galoisrepresentations.com/feed/
 https://www.gannetdesigns.com/feed/
 https://www.garethrees.co.uk/feed.xml
 https://www.garrisonkeillor.com/feed/


### PR DESCRIPTION
I'm not entirely sure about these decisions, that's why I put them into a separate PR.

The parked domain should be a no-brainer, we had cases like this before and just removed them. But I don't know about the suspended accounts. They could be gone for good, so we could just remove them. On the other hand, maybe life happened, the accounts got suspended for inactivity or something and they will bounce back some time in the future.

I don't know. Up for you to decide. ;)