### PR TITLE
Remove Abandoned Online blog

### DIFF
--- a/smallweb.txt
+++ b/smallweb.txt
@@ -464,7 +464,6 @@ https://aaronweb.net/feed/
 https://aartaka.me/rss.xml
 https://aaugh.com/wordpress/feed/
 https://abandoned.photos/rss
-https://abandonedonline.net/feed/
 https://abbbi.github.io/feed.xml
 https://abbesroad.blog/feed/
 https://abcl-dev.blogspot.com/feeds/posts/default


### PR DESCRIPTION
This blog does not adhere to Kagi Small Web guidelines - has newsletter popup.

- [ ] "Site should not have newsletter signup popups (substack sites are not accepted too)"

## Example

Article example direct link: https://abandonedonline.net/an-abandoned-homestead-at-the-edge-of-a-spaceport/

## Screenshots

![A webpage from "Abandoned Online" showing a grid of images of an abandoned homestead, with a central newsletter popup prompting users to subscribe by entering their email. The Kagi Small Web navigation bar is visible at the top.](https://github.com/user-attachments/assets/e97878e3-643f-4c98-bcf0-ca10c246040a)

