### PR TITLE
Remove EatonPhil blog - not embeddable

### DIFF
--- a/smallweb.txt
+++ b/smallweb.txt
@@ -8997,7 +8997,6 @@ https://notes.billmill.org/blog.atom.xml
 https://notes.billmill.org/link_blog.atom.xml
 https://notes.billmill.org/music_blog.atom.xml
 https://notes.colfer.net/feed.rss
-https://notes.eatonphil.com/rss.xml
 https://notes.ericjiang.com/feed
 https://notes.ghed.in/feed.xml
 https://notes.husk.org/rss


### PR DESCRIPTION
Blog cannot be embedded in iframe. notes.eatonphil.com redirects to enterprisedb.com, which does not allow itself to be embedded. 

Small Web link: https://kagi.com/smallweb/?url=http%3A%2F%2Fnotes.eatonphil.com%2F2025-05-22-debugging-memory-leaks-postgres-heaptrack-edition.html

## Screenshots

![Firefox warning message - To protect your security, www.enterprisedb.com will not allow Firefox to display the page if another site has embedded it. To see this page, you need to open it in a new window.](https://github.com/user-attachments/assets/3b8b1942-6d59-48b2-a43b-e783ef4e83d1)

![Opera cannot display iframe warning.](https://github.com/user-attachments/assets/fc368c3e-01ed-4711-ba55-6124e62add9d)

