### PR TITLE
Remove HyperOrg.com blog - 404s

### DIFF
--- a/smallweb.txt
+++ b/smallweb.txt
@@ -13626,7 +13626,6 @@ https://www.huy.dev/rss.xml
 https://www.huy.rocks/rss.xml
 https://www.hxa.name/hxa7241-latest.xml
 https://www.hypergeometric.com/feed/
-https://www.hyperorg.com/blogger/feed/atom/
 https://www.hypertesto.me/en/index.xml
 https://www.iainsinclair.org.uk/feed/
 https://www.iamadamlevy.com/feed/


### PR DESCRIPTION
Articles no longer show - 404 error.

Small Web link: https://kagi.com/smallweb/?url=https%3A%2F%2Fwww.hyperorg.com%2Fblogger%2F2025%2F05%2F21%2Fllms-jokes-for-other-llms%2F

## Screenshots

![A webpage from "Joho the Blog" displaying a "Not Found" message in red text, indicating the requested content is unavailable. The page includes book covers and links to related content at the top and a Creative Commons license notice at the bottom. The Kagi Small Web navigation bar is visible at the top.](https://github.com/user-attachments/assets/ceb1cbc6-ef2a-4340-b0c9-8d191e92754d)

It seems like there was supposed to be a genuine article on 5/21, but not sure if this is some type of anti-bot measure. Because the blog 404s under all conditions.