### PR TITLE
Fix YouTube URL parsing KeyError

### DIFF
--- a/app/sw.py
+++ b/app/sw.py
@@ -329,8 +329,10 @@ def index():
 
     if "youtube.com" in short_url:
         parsed_url = urlparse(url)
-        videoid = parse_qs(parsed_url.query)["v"][0]
-        current_mode = 1
+        query_params = parse_qs(parsed_url.query)
+        if "v" in query_params:
+            videoid = query_params["v"][0]
+            current_mode = 1
 
     # get favorites
     reactions_dict = favorites_dict.get(url, OrderedDict())


### PR DESCRIPTION
This PR fixes a server 500 error when URL contains 'youtube.com' in path but isn't a YouTube video. I was browsing Small Web when I ended up on this URL, which is currently broken:

`https://kagi.com/smallweb/?url=https%3A%2F%2Fmarkjgsmith.com%2Flinks%2F2025%2F07%2F27%2F234134-www.youtube.com`

The YouTube detection logic checks if "youtube.com" appears anywhere in the URL and then assumes it's a YouTube video — this fails with a KeyError when the URL contains "youtube.com" in the path but has no "v" query parameter.

Added a check to verify the "v" parameter exists before trying to access it.

Confirmed on local dev that the production URL is broken, and that this PR fixes it.