### PR TITLE
Add new RSS feed for proustonomics.com

### DIFF
--- a/xcazin
+++ b/xcazin
@@ -15489,6 +15489,7 @@ https://protocols-made-fun.com/feed.xml
 https://protocolsnow.com/rss/
 https://protonsforbreakfast.wordpress.com/feed/
 https://protoweb.org/feed/
+https://proustonomics.com/feed/
 https://prozak.org/rss/
 https://prtksxna.com/feed/
 https://prvn.sh/rss/


### PR DESCRIPTION
Proustonomics is an all-Proust blog in French that includes premium content from Nicolas Ragonneau, a reknowned Proust specialist.