### PR TITLE
Added three new entries to RSS feed list

### DIFF
--- a/smallweb.txt
+++ b/smallweb.txt
@@ -2901,7 +2901,6 @@ https://billprin.com/rss/feed.xml
 https://billsaysthis.com/feed/
 https://billwadge.com/feed/
 https://billyoppenheimer.com/feed/
-https://blog.binaergewitter.de/rss.xml
 https://binal.pub/index.xml
 https://binarybonsai.com/blog?format=rss
 https://binarydebt.wordpress.com/feed/
@@ -4598,6 +4597,7 @@ https://boakandbailey.com/feed/
 https://boat.karlnelson.net/index.xml
 https://boats16.blogspot.com/feeds/posts/default
 https://boazsobrado.com/index.xml
+https://bobdahacker.com/feed.xml
 https://bob.blog/feed/
 https://bob.ippoli.to/feed.atom
 https://bobacupcake.com/feed.xml


### PR DESCRIPTION
Thanks for the great work on kagi in general and kagi smallweb

I added three new entries to the RSS feed list: 
1. bobdahacker.com is a blog from an ethical hacker talking about security vulnerabilities and reports
2. davetang.org is a blog about computational biology and genomics, on top of other cs related things
3. brt.fyi (my personal blog) about cs, engineering, 3d printing and books