### PR TITLE
changing full list url path according to production

### DIFF
--- a/app/static/smallweb-queue.js
+++ b/app/static/smallweb-queue.js
@@ -6,7 +6,7 @@
   'use strict';
 
   const DEFAULT_CONFIG = {
-    fullListUrl: '/smallweb/appreciated.json',
+    fullListUrl: '/appreciated.json',
     enablePeriodicResetQueue: true,
     periodicResetQueueMinutes: 720,
     checkOnExhaustion: true,


### PR DESCRIPTION
This is fix from my previous PR which is merged. 
I just realized by testing production smallweb that the prefix is different for localhost and production, hence removing "smallweb" from url path as it was extra add-on

Current URL path in production - https://kagi.com/smallweb/smallweb/appreciated.json - 404
Fixed URL path in production - https://kagi.com/smallweb/appreciated.json

Note - this is not breaking any functionality as it by default falls back to existing logic but its not enabling my fix. 