### PR TITLE
Add new RSS feed URLs to smallweb.txt

### DIFF
--- a/smallweb.txt
+++ b/smallweb.txt
@@ -148,6 +148,7 @@ http://cravacuore.com.ar/blog/feed
 http://crpgaddict.blogspot.com/feeds/posts/default
 http://crschmidt.net/blog/feed/atom/
 http://cryto.net/~joepie91/blog/feed.xml
+https://cthoyt.com/feed.xml
 http://culturalsnow.blogspot.com/atom.xml
 http://curiousordinary.com/feeds/posts/default
 http://cwinters.com/feeds/cwinters.atom
@@ -23123,6 +23124,7 @@ https://vgkids.github.io/obtf-2/feed.xml
 https://vgmpf.com/Wiki/index.php?title=Special:RecentChanges&feed=atom
 https://vgnotepad.blogspot.com/feeds/posts/default
 https://vgpena.github.io/feed.xml
+https://vgrass.de/feed/atom/
 https://vgsmproject.com/feed/
 https://vhanda.in/rss.xml
 https://vhbelvadi.com/rss


### PR DESCRIPTION
This pull request adds two new RSS/Atom feed URLs to the `smallweb.txt` file, expanding the list of tracked blogs.

Feed additions:

* Added `https://cthoyt.com/feed.xml` to the list of blog feeds.
* Added `https://vgrass.de/feed/atom/` to the list of blog feeds.