### PR TITLE
Add 3 new RSS feed URLs to smallweb.txt

### DIFF
--- a/smallweb.txt
+++ b/smallweb.txt
@@ -3867,6 +3867,7 @@ https://blog.hakanserce.com/index.xml
 https://blog.halfvast.com/feed/
 https://blog.hansenpartnership.com/feed/
 https://blog.hao.dev/rss.xml
+https://blog.haojin.li/index.xml
 https://blog.happyfellow.dev/atom/
 https://blog.harrison.dev/feed.xml
 https://blog.harterrt.com/feeds/all.atom.xml
@@ -11071,6 +11072,7 @@ https://honest-food.net/atom/
 https://honeybeesuite.com/atom/
 https://honeypot.net/feed.xml
 https://hongchao.me/feed.xml
+https://hongtaoh.com/en/index.xml
 https://honisoit.com/feed
 https://honk.sigxcpu.org/con/index.rss
 https://honkathon.com/index.xml
@@ -13773,6 +13775,7 @@ https://lawcomic.net/guide/?feed=rss2
 https://lawler.io/feeds/all.atom.xml
 https://lawrence.lu/blog/rss.xml
 https://lawrencecpaulson.github.io/feed.xml
+https://lawtee.com/en/index.xml
 https://lawver.net/feed/
 https://lawverearchives.com/feed/
 https://laxmena.com/feed/


### PR DESCRIPTION
Three personal blogs have been added according to the instructions:   
1. https://blog.haojin.li/  
2. https://hongtaoh.com/en/  
3. https://lawtee.com/en/