### PR TITLE
Remove 2 sites

### DIFF
--- a/smallweb.txt
+++ b/smallweb.txt
@@ -5041,7 +5041,6 @@ https://bogost.com/feed/
 https://bogs.io/feed
 https://bohemianvalley.tech/feed/
 https://bohops.com/feed/
-https://boilingsteam.com/feed/rss-feed.xml
 https://boinkor.net/index.xml
 https://boisdejasmin.com/feed
 https://bojanvidanovic.com/index.xml


### PR DESCRIPTION
None of these are personal blogs, and the raspberry pi site also had newsletter popups.