### PR TITLE
Add aaron.com.es and two other blogs

### DIFF
--- a/smallweb.txt
+++ b/smallweb.txt
@@ -932,6 +932,7 @@ https://aaron-hoffman.blogspot.com/feeds/posts/default
 https://aaron.axvigs.com/rss.xml
 https://aaron.blog/feed/
 https://aaron.cc/rss/
+https://aaron.com.es/index.xml
 https://aaron.leaflet.pub/atom
 https://aaron.vegh.ca/rss.xml
 https://aaronarney.dev/rss.xml
@@ -6236,6 +6237,7 @@ https://clintberry.com/index.xml
 https://clintbrown.co.uk/feed/
 https://clintmcmahon.com/feed/
 https://clintondreisbach.com/atom/
+https://cliophate.wtf/feed/posts
 https://clipperhouse.com/index.xml
 https://clippingsilver.com/atom.xml
 https://clojure-goes-fast.com/blog/atom.xml
@@ -8458,6 +8460,7 @@ https://emberandplume.com/atom/
 https://embrace-autism.com/feed/
 https://embraceasd.com/rss/
 https://embracethered.com/blog/index.xml
+https://emdash.codes/feed/
 https://emdrhealing.com/feed
 https://eme64.github.io/blog/feed.xml
 https://emeraldsip.cafe/atom/


### PR DESCRIPTION
## Summary
- Add [aaron.com.es](https://aaron.com.es)
- Add [cliophate.wtf](https://cliophate.wtf)
- Add [emdash.codes](https://emdash.codes)

First one is my personal blog and I am excited to be part of this initiative!
The other two are additional blogs I follow, included to meet the 1+2 rule.

All three are personal blogs with recent content in English, no ads, and no newsletter popups.