### PR TITLE
Add partytab.app, kevinquinn.fun, and registerspill.thorstenball.com

### DIFF
--- a/smallweb.txt
+++ b/smallweb.txt
@@ -13669,6 +13669,7 @@ https://kevin.me/feed/
 https://kevin.the.li/rss.xml
 https://kevin3010.github.io/feed.xml
 https://kevin49999.github.io/feed.xml
+https://kevinquinn.fun/feed.xml
 https://kevinanderson.nl/feed/
 https://kevinavignon.com/atom/
 https://kevinbellco.com/atom/
@@ -17934,6 +17935,7 @@ https://particulations.blogspot.com/feeds/posts/default
 https://partofthething.com/feed/
 https://partofthething.com/thoughts/feed/
 https://partridge.works/feed/atom/
+https://partytab.app/blog/feed.xml
 https://parucker.wordpress.com/feed/
 https://parv.bearblog.dev/feed/
 https://parveensingh.com/feed/
@@ -19377,6 +19379,7 @@ https://refsmmat.com/rss.xml
 https://refugionorte.com/feed/atom/
 https://regex.info/blog/rss/
 https://regexking.info/index.xml
+https://registerspill.thorstenball.com/feed
 https://regulargeek.com/feed/
 https://rehansaeed.com/feed/
 https://reichel.dev/rss.xml


### PR DESCRIPTION
Adding 3 new blogs to the Small Web:

### New entries

1. **https://partytab.app/blog/feed.xml** — PartyTab's blog with educational guides on splitting expenses for trips, dinners, and roommates. Ad-free, no popups.

2. **https://kevinquinn.fun/feed.xml** — Personal blog by Kevin Quinn, a software engineer writing about tech, productivity, and ideas. Hugo-powered, ad-free. Latest post: Nov 2025.

3. **https://registerspill.thorstenball.com/feed** — Register Spill by Thorsten Ball (author of "Writing An Interpreter In Go"). Weekly programming newsletter/blog. Latest post: Feb 8, 2026.

Per contribution guidelines, submitting my own site (partytab.app) alongside 2 other independent blogs not already in the list.