### PR TITLE
Update smallweb.txt to remove AI slop site

### DIFF
--- a/smallweb.txt
+++ b/smallweb.txt
@@ -23260,7 +23260,6 @@ https://st0012.dev/feed
 https://staaldraad.github.io/index.xml
 https://stable-diffusion-art.com/feed/atom/
 https://stachu.net/rss/
-https://stack-junkie.com/feed.xml
 https://stack55.com/feed/feed.xml
 https://stackabuse.com/rss/
 https://stackallocated.com/atom.xml


### PR DESCRIPTION
Removed stack-junkie.com for becoming low-quality AI content, as per https://kagifeedback.org/d/10037-ai-slop-in-small-web-results

## Checklist
- [ ] I have read the [guidelines](README.md#-guidelines-for-adding-a-site-or-channel-to-the-list--)

Also if submitting your own website you must add at least 2 other sites that are not yours (and are not in list yet) in the same commit:
1.
2.
