### PR TITLE
Remove obsolete susam.in URL

### DIFF
--- a/smallweb.txt
+++ b/smallweb.txt
@@ -24223,7 +24223,6 @@ https://surma.dev/index.xml
 https://surplusenergyeconomics.wordpress.com/atom/
 https://surreal-m.neocities.org/rss/rss.xml
 https://survivejs.com/atom.xml
-https://susam.in/feed.xml
 https://susam.net/feed.xml
 https://susancain.net/feed/
 https://susankayequinn.com/feed


### PR DESCRIPTION
My personal website moved from https://susam.in/ to https://susam.net/ in 2022.  The new URL is already present in smallweb.txt.  This change removes the old URL that is now obsolete.

Thank you for creating this wonderful project.

## Checklist
- [x] I have read the [guidelines](README.md#-guidelines-for-adding-a-site-or-channel-to-the-list--)

Also if submitting your own website you must add at least 2 other sites that are not yours (and are not in list yet) in the same commit:

1. N/A (I am not adding a website but deleting an obsolete link.)
2. N/A (I am not adding a website but deleting an obsolete link.)
