### PR TITLE
Add JavaScript to update the browser's URL with a missing 'url' query parameter.

### DIFF
--- a/app/templates/index.html
+++ b/app/templates/index.html
@@ -418,5 +418,16 @@ href="https://github.com/kagisearch/smallweb" target="_blank" rel="noopener nore
   {% endif %}
   </main>
 
+  {% if not request.args.get('url') and url %}
+  <script>
+    (function() {
+      const currentUrlParams = new URLSearchParams(window.location.search);
+      currentUrlParams.set('url', "{{url}}");
+      const newUrl = window.location.pathname + '?' + currentUrlParams.toString();
+      window.history.replaceState(null, '', newUrl);
+    })();
+  </script>
+  {% endif %}
+  
 </body>
 </html>


### PR DESCRIPTION
See https://github.com/kagisearch/smallweb/issues/635.

## Checklist
- [x] I have read the [guidelines](README.md#-guidelines-for-adding-a-site-or-channel-to-the-list--)

