### PR TITLE
Removed s-anand.net for AI

### DIFF
--- a/smallweb.txt
+++ b/smallweb.txt
@@ -32722,7 +32722,6 @@ https://www.ryantoken.com/feed.rss
 https://www.ryantolsma.com/feed.xml
 https://www.ryeones.com/feed.xml
 https://www.rykap.com/feed.xml
-https://www.s-anand.net/blog/feed/
 https://www.s-config.com/feed/
 https://www.saabplanet.com/feed/atom/
 https://www.sabih.dev/rss.xml


### PR DESCRIPTION
This was the first post I saw when I found Kagi Small Web: https://www.s-anand.net/blog/ai-palmistry/

Not a great first impression, but I was relieved to see this was explicitly disallowed.

> No auto generated, LLM generated or spam content.

Nearly every single post of theirs has an AI generated image and the content is... obsessed with AI. Whether the posts are fully written in AI, I don't care to investigate. This should be enough.