### PR TITLE
Correct existing link to rmendes.net feed URL

### DIFF
--- a/smallweb.txt
+++ b/smallweb.txt
@@ -5438,7 +5438,6 @@ https://blog.rinesi.com/feed
 https://blog.rishabkumar.com/rss.xml
 https://blog.ritekit.com/home.rss
 https://blog.rlmflores.me/atom.xml
-https://blog.rmendes.net/feed.xml
 https://blog.rmorrison.org/posts.atom
 https://blog.rnstlr.ch/feeds/all.atom.xml
 https://blog.roastidio.us/feed.xml
@@ -22948,6 +22947,7 @@ https://rlaanemets.com/atom.xml
 https://rldane.space/feeds/all.atom.xml
 https://rm4n0s.github.io/index.xml
 https://rmarcus.info/blog/atom.xml
+https://rmendes.net/feed.xml
 https://rmoff.net/index.xml
 https://rmondello.com/feed
 https://rmosolgo.github.io/feed.xml


### PR DESCRIPTION
Someone kindly added my blog to the smallweb collection but using the old domain **blog.rmendes.net/feed.xml** the correct link is **rmendes.net/feed.xml**
I fixed the correct link
I sorted it properly in the R entries instead of B

## Checklist
- [x] I have read the [guidelines](README.md#-guidelines-for-adding-a-site-or-channel-to-the-list--)


