### PR TITLE
Add unformeddelta.wiki, conq.blog, smorgasb.org feeds

### DIFF
--- a/smallweb.txt
+++ b/smallweb.txt
@@ -7737,6 +7737,7 @@ https://connorberry.com/feed
 https://connorboyle.io/feed.xml
 https://connormcgarr.github.io/feed
 https://connortumbleson.com/rss
+https://conq.blog/feed
 https://conormclaughlin.net/index.xml
 https://conorneill.com/atom
 https://conoroneill.net/index.xml
@@ -24552,6 +24553,7 @@ https://smolnero.com/feed
 https://smolweb.org/atom.xml
 https://smoores.dev/recent.atom
 https://smoothbrains.net/atom.xml
+https://smorgasb.org/feed.xml
 https://smpetz.blogspot.com/feeds/posts/default
 https://smsohan.com/index.xml
 https://smth.uk/feed/articles.xml
@@ -27392,6 +27394,7 @@ https://unfinished.bike/feed
 https://unfoldingdiagrams.leaflet.pub/atom
 https://unfoldingneurons.com/feed
 https://unfooling.com/feed.xml
+https://unformeddelta.wiki/feed.xml
 https://uni-watch.com/feed/atom
 https://unicks.ninja/index.xml
 https://unimplementedtrap.com/feed.xml


### PR DESCRIPTION
## Checklist
- [x] I have read the [guidelines](https://github.com/kagisearch/smallweb/blob/main/README.md#%EF%B8%8F-guidelines-for-site-inclusion-to-the-list-%EF%B8%8F)

Also if submitting your own website (unformeddelta.wiki) you must add at least 2 other sites that are not yours (and are not in list yet) in the same commit:
1. conq.blog
2. smorgasb.org
