### PR TITLE
Modify like functionality on web to stop redirect to new page

### DIFF
--- a/app/templates/index.html
+++ b/app/templates/index.html
@@ -411,5 +411,91 @@ href="https://github.com/kagisearch/smallweb" target="_blank" rel="noopener nore
     </div>
   {% endif %}
   </main>
+  <script>
+  (function() {
+    var LIKE_EXPIRY_MS = 7 * 24 * 60 * 60 * 1000;
+
+    function likeKey(url, emoji) {
+      var hash = 0;
+      for (var i = 0; i < url.length; i++) {
+        hash = ((hash << 5) - hash + url.charCodeAt(i)) | 0;
+      }
+      return 'sw_like_' + hash + '_' + emoji;
+    }
+
+    function hasLiked(url, emoji) {
+      try {
+        var val = localStorage.getItem(likeKey(url, emoji));
+        if (!val) return false;
+        if (Date.now() - parseInt(val, 10) > LIKE_EXPIRY_MS) {
+          localStorage.removeItem(likeKey(url, emoji));
+          return false;
+        }
+        return true;
+      } catch(e) { return false; }
+    }
+
+    function markLiked(url, emoji) {
+      try { localStorage.setItem(likeKey(url, emoji), Date.now().toString()); }
+      catch(e) {}
+    }
+
+    document.querySelectorAll('.emoji-form').forEach(function(form) {
+      var urlInput = form.querySelector('input[name="url"]');
+      var emojiInput = form.querySelector('input[name="emoji"]');
+      if (!urlInput || !emojiInput) return;
+
+      var url = urlInput.value;
+      var emoji = emojiInput.value;
+      var btn = form.querySelector('button[type="submit"]');
+
+      if (hasLiked(url, emoji)) {
+        btn.classList.add('already-liked');
+        btn.style.opacity = '0.5';
+        btn.style.pointerEvents = 'none';
+        btn.title = 'Already liked';
+      }
+
+      form.addEventListener('submit', function(e) {
+        e.preventDefault();
+        if (hasLiked(url, emoji)) return;
+
+        btn.style.pointerEvents = 'none';
+
+        fetch('{{ prefix }}api/like', {
+            method: 'POST',
+            headers: { 'Content-Type': 'application/json' },
+            body: JSON.stringify({ url: url, emoji: emoji })
+          })
+          .then(function(r) { return r.json(); })
+          .then(function(data) {
+            if (!data.ok) return;
+            markLiked(url, emoji);
+            btn.classList.add('already-liked');
+            btn.style.opacity = '0.5';
+            btn.style.pointerEvents = 'none';
+            btn.title = 'Already liked';
+
+            if (emoji === '\uD83D\uDC4D') {
+              var span = btn.querySelector('span');
+              if (span) {
+                span.textContent = data.reaction_count;
+              } else {
+                var s = document.createElement('span');
+                s.textContent = data.reaction_count;
+                btn.appendChild(s);
+              }
+            } else {
+              var spans = btn.querySelectorAll('span');
+              if (spans.length >= 2) spans[1].textContent = data.reaction_count;
+            }
+          })
+          .catch(function() {
+            btn.style.pointerEvents = '';
+          });
+      });
+    });
+  })();
+  </script>
 </body>
 </html>

--- a/app/templates/index.html
+++ b/app/templates/index.html
@@ -414,6 +414,22 @@ href="https://github.com/kagisearch/smallweb" target="_blank" rel="noopener nore
   <script>
   (function() {
     var LIKE_EXPIRY_MS = 7 * 24 * 60 * 60 * 1000;
+    var SWEEP_INTERVAL_MS = 24 * 60 * 60 * 1000;
+
+    try {
+      var now = Date.now();
+      var lastSweep = parseInt(localStorage.getItem('sw_like_sweep'), 10) || 0;
+      if (now - lastSweep > SWEEP_INTERVAL_MS) {
+        for (var i = localStorage.length - 1; i >= 0; i--) {
+          var key = localStorage.key(i);
+          if (key && key.indexOf('sw_like_') === 0 && key !== 'sw_like_sweep') {
+            var ts = parseInt(localStorage.getItem(key), 10);
+            if (!ts || now - ts > LIKE_EXPIRY_MS) localStorage.removeItem(key);
+          }
+        }
+        localStorage.setItem('sw_like_sweep', now.toString());
+      }
+    } catch(e) {}
 
     function likeKey(url, emoji) {
       var hash = 0;


### PR DESCRIPTION
## Summary

On web, when a user likes any post, it instantly redirects to a new post which is 
confusing - I'm just liking a post but haven't finished reading it. Also, the same 
post can be liked again and again since there's no client-side storage. I verified 
that the app already handles this correctly (likes without navigating away).

## Changes

1. From FE, now calls `/api/like` (existing JSON endpoint) instead of form-submitting 
   to `/like`, so it returns JSON without a page redirect
2. Updated FE code to handle the JSON response and show the increased like count on 
   the button in-place
3. Disabled users from liking the same post again by storing likes in localStorage
4. Added a daily sweep to remove localStorage entries older than 7 days, so 
   localStorage doesn't accumulate over time

## Before

<video src="https://github.com/user-attachments/assets/20270a08-73e1-45c0-a638-6e9560d72823" controls width="600"></video>

## After

<video src="https://github.com/user-attachments/assets/c3408aff-f306-459d-9acf-3193960dcce7" controls width="600"></video>


## Test plan

- [x] Click an emoji on a post — page should NOT redirect; count should increment
- [x] Reload the page — the same emoji button should appear dimmed/disabled
- [x] Test with localStorage unavailable (private browsing) — liking should still work

