### PR TITLE
Remove theautomaticearth.com spam

### DIFF
--- a/smallweb.txt
+++ b/smallweb.txt
@@ -11345,7 +11345,6 @@ https://feeds.feedburner.com/TeacherTom
 https://feeds.feedburner.com/TernausBlog
 https://feeds.feedburner.com/terrigriffith/goOj
 https://feeds.feedburner.com/TheArtOfManliness
-https://feeds.feedburner.com/theautomaticearth/OCyb
 https://feeds.feedburner.com/TheCodeArtist
 https://feeds.feedburner.com/TheCrpgAddict
 https://feeds.feedburner.com/theendeavour


### PR DESCRIPTION
This website is nonsensical (potentially automated) spam, just of hundreds of thousands of tweets embedded or their text copied.

And it has a cookie popup.

## Checklist
- [x] I have read the [guidelines](https://github.com/kagisearch/smallweb/blob/main/README.md#%EF%B8%8F-guidelines-for-site-inclusion-to-the-list-%EF%B8%8F)

Also if submitting your own website you must add at least 2 other sites that are not yours (and are not in list yet) in the same commit:
1.
2.
