### PR TITLE
Add new RSS feed URLs to smallweb.txt

### DIFF
--- a/smallweb.txt
+++ b/smallweb.txt
@@ -18825,6 +18825,8 @@ https://melody.dev/feed/feed.xml
 https://melomac.com/index.xml
 https://melon.industries/feed/
 https://melon.zone/feed.xml
+https://technically-good.ca/feed/?type=rss
+https://vics.bearblog.dev/feed/?type=rss
 https://melonds.kuribo64.net/rss.php
 https://melonsoda.nekoweb.org/feed.xml
 https://meltingasphalt.com/atom
@@ -19484,6 +19486,7 @@ https://monoinfinito.wordpress.com/feed
 https://monokai.com/rss.xml
 https://monolith-project.org/index.xml
 https://monolog.xyz/atom
+https://monoart.nekoweb.org/rss.xml
 https://monome.org/rss.xml
 https://monospace.games/feed.atom
 https://monospacementor.com/feed


### PR DESCRIPTION
## Checklist
- [x] I have read the [guidelines](https://github.com/kagisearch/smallweb/blob/main/README.md#%EF%B8%8F-guidelines-for-site-inclusion-to-the-list-%EF%B8%8F)

Also if submitting your own website you must add at least 2 other sites that are not yours (and are not in list yet) in the same commit:
1. https://technically-good.ca/feed/?type=rss
2. https://vics.bearblog.dev/feed/?type=rss
