### PR TITLE
rss: added RSS feed for three sites

### DIFF
--- a/smallweb.txt
+++ b/smallweb.txt
@@ -6102,6 +6102,7 @@ https://bloggeek.me/atom
 https://bloggerbust.ca/index.xml
 https://bloggeroo.dev/rss.xml
 https://blogicarian.blogspot.com/feeds/posts/default
+https://blogin-the-goblin.com/rss.xml
 https://blogmaverick.com/feed
 https://blogofdrew.bearblog.dev/feed
 https://blogomancer.bearblog.dev/feed
@@ -17980,6 +17981,7 @@ https://makeitdairyfree.com/feed
 https://makeupandbeautyblog.com/feed
 https://makingcomputerdothings.com/atom
 https://makingmaps.net/feed
+https://makiroll.space/updates.xml
 https://makki.moe/feeds/rss.xml
 https://maknee.github.io/feed.xml
 https://mako.cc/copyrighteous/feed/atom
@@ -18799,6 +18801,7 @@ https://mediterraneanworld.wordpress.com/feed
 https://medium.marco.zone/feed
 https://mediumsandmessages.bearblog.dev/feed
 https://mediumsecond.com/rss
+https://medjed.nekoweb.org/rss.xml
 https://medo64.com/feed
 https://medriscoll.com/feed
 https://medusalix.github.io/index.xml


### PR DESCRIPTION
added three sites to `smallweb.txt`.

- medjed.nekoweb.org
- blogin-the-goblin.com
- makiroll.space

## Checklist
- [x] I have read the [guidelines](https://github.com/kagisearch/smallweb/blob/main/README.md#%EF%B8%8F-guidelines-for-site-inclusion-to-the-list-%EF%B8%8F)
- [x] Also if submitting your own website you must add at least 2 other sites that are not yours (and are not in list yet) in the same commit
