### PR TITLE
rss: removed violating sites

### DIFF
--- a/smallweb.txt
+++ b/smallweb.txt
@@ -21830,7 +21830,6 @@ https://personal.garrettfuller.org/blog/rss
 https://personal.jatan.space/feed.xml
 https://personalinfocloud.com/feed
 https://personalsit.es/feed/all.xml
-https://perspective-collective.com/atom.xml
 https://perspectives.mvdirona.com/feed
 https://perspicacityll.wpengine.com/feed
 https://persumi.com/u/fredwu/feed/atom

--- a/smallweb.txt
+++ b/smallweb.txt
@@ -7888,7 +7888,6 @@ https://colinwoodard.com/feed
 https://coliveira.net/atom
 https://collantes.us/index.xml
 https://collectivedecember.neocities.org/index.xml
-https://collectiveidea.com/blog/feed.xml
 https://collectiveiq.wordpress.com/feed
 https://collectivesafetynet.blogspot.com/feeds/posts/default
 https://colleenrobb.com/feed

--- a/smallweb.txt
+++ b/smallweb.txt
@@ -31095,7 +31095,6 @@ https://www.ebiester.com/feed.xml
 https://www.echevarria.io/rss.xml
 https://www.eclipseatlas.com/blog?format=rss
 https://www.ecliptik.com/feed.xml
-https://www.ecommercefuel.com/feed
 https://www.economicpopulist.com/crss
 https://www.ecoshock.org/feed/atom
 https://www.ecosophia.net/feed

--- a/smallweb.txt
+++ b/smallweb.txt
@@ -8021,7 +8021,6 @@ https://cookingwithgaul.com/feed
 https://cool-as-heck.blog/feed/?type=rss
 https://coolbutuseless.github.io/index.xml
 https://coolcalvary.com/feed/atom
-https://coolmomtech.com/feed/atom
 https://coolsocks.lol/feed.xml
 https://cooltrainer.org/feed.xml
 https://coopergyoung.com/feed

--- a/smallweb.txt
+++ b/smallweb.txt
@@ -1774,10 +1774,6 @@ https://albertogalca.com/feed.xml
 https://albertpedersen.com/index.xml
 https://albertsikkema.com/feed.xml
 https://alchemistnocturne.blogspot.com/atom.xml
-https://alchemists.io/feeds/articles.xml
-https://alchemists.io/feeds/news.xml
-https://alchemists.io/feeds/projects.xml
-https://alchemists.io/feeds/talks.xml
 https://alco.rocks/rss.xml
 https://aldeid.com/feed
 https://alden.page/feed.xml
@@ -29759,7 +29755,6 @@ https://www.alasdairb.com/rss.xml
 https://www.albertovarela.net/index.xml
 https://www.albertplaya.com/rss.xml
 https://www.albertyw.com/atom.xml
-https://www.alchemists.io/feeds/news.xml
 https://www.aldeid.com/rss
 https://www.aldrovanda.com/feed.xml
 https://www.alec.fyi/feed

--- a/smallweb.txt
+++ b/smallweb.txt
@@ -12813,8 +12813,6 @@ https://grossack.site/feed.xml
 https://grosser.it/feed
 https://groundbasedspacematters.com/index.php/feed
 https://groundzeno.net/feed.xml
-https://group.miletic.net/feed_json_created.json
-https://group.miletic.net/feed_rss_created.xml
 https://groverlab.org/feed.xml
 https://groveronline.com/feed
 https://growingswe.com/feed.xml


### PR DESCRIPTION
Removed sites that did not follow the guidelines. I split the removals to indivudal commits

# sites removed

 removed `perspective-collective.com`
 - the domain redirects to `coachscottyrussell.com`
 - which sells coaching services

removed `group.miletic.net`
- cookie selection pop up
- non-English

removed `coolmomtech.com`
- has a Curated Shopping page that redirects to `coolmompicks.com`, which basically "recommends" you stuff to buy
- multiple authors, not a personal blog

removed `collectiveidea.com`
- a company's blog, not a personal blog

removed `ecommercefuel.com`
- this is a paid membership community
- not a personal blog; multiple authors

removed `alchemist.io`
 - not a personal blog
 - seemed to be a consulting firm

# Checklist
- [x] I have read the [guidelines](https://github.com/kagisearch/smallweb/blob/main/README.md#%EF%B8%8F-guidelines-for-site-inclusion-to-the-list-%EF%B8%8F)
- [x] Removes the site if it does not adhere to the above guidelines
- [x] In the removal request, state which guideline does it break