### PR TITLE
Add new RSS feed URLs to smallweb.txt

### DIFF
--- a/smallweb.txt
+++ b/smallweb.txt
@@ -9777,6 +9777,7 @@ https://doubleagent.net/rss
 https://doubleclix.wordpress.com/feed
 https://doublefree.dev/atom
 https://doubleloop.net/feed
+https://doublepulsar.com/feed
 https://doubtmark.bearblog.dev/feed
 https://doug.lon.dev/atom.xml
 https://doug.pub/atom.xml
@@ -18031,6 +18032,7 @@ https://mango.pdf.zone/feed.xml
 https://maniacs.bearblog.dev/feed/
 https://manish.bearblog.dev/feed
 https://manishearth.github.io/atom.xml
+https://manishrawat21.substack.com/feed
 https://manishrjain.com/feed.rss
 https://mannerofspeaking.org/feed
 https://manoj.ninja/feed.xml
@@ -27421,6 +27423,7 @@ https://theschoolofthetransferofenergy.com/feed
 https://thescoop.org/blog.xml
 https://thesecondbutton.com/rss/
 https://theseconddisc.com/feed/atom
+https://thesecondfactor.com/feed/
 https://thesecretknots.com/feed
 https://thesephist.com/index.xml
 https://theservitor.com/feed


### PR DESCRIPTION
Add feeds:
https://thesecondfactor.com/feed/
https://doublepulsar.com/feed
https://manishrawat21.substack.com/feed

## Checklist
- [X] I have read the [guidelines](https://github.com/kagisearch/smallweb/blob/main/README.md#%EF%B8%8F-guidelines-for-site-inclusion-to-the-list-%EF%B8%8F)

Also if submitting your own website you must add at least 2 other sites that are not yours (and are not in list yet) in the same commit:
1.https://doublepulsar.com/feed
2.https://manishrawat21.substack.com/feed
