### PR TITLE
Add Impermanente English edition

### DIFF
--- a/smallweb.txt
+++ b/smallweb.txt
@@ -887,6 +887,9 @@ http://zackmdavis.net/blog/feed
 http://zuiker.com/rss
 http://zvis.com/blog/php/feedgen.php?0
 http://zyst.io/feed.xml
+https://en.impermanente.es/feed.xml
+https://ville.saalo.moi/feed.xml
+https://williamjansson.com/feed.xml
 https://マリウス.com/index.xml
 https://%C5%A1ime.eu/feed.xml
 https://%CE%BC.computer/@theterg.rss


### PR DESCRIPTION
Adds three English-language personal blog feeds:

- https://en.impermanente.es/feed.xml — selected English essays by J.R. Cruciani, translated and edited from the Spanish originals; independent feed, no ads/popups.
- https://ville.saalo.moi/feed.xml — personal blog by Ville Saalo.
- https://williamjansson.com/feed.xml — personal blog by William Jansson.

Impermanente is my own site, so this PR includes two additional sites that are not mine and were not already in smallweb.txt.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Add three English-language personal blog RSS feeds to smallweb.txt. Expands the Small Web list with the Impermanente English edition and two independent blogs.

- **New Features**
  - https://en.impermanente.es/feed.xml
  - https://ville.saalo.moi/feed.xml
  - https://williamjansson.com/feed.xml

<sup>Written for commit 9163f0ec5f9a6c0cdde23f2064d704d99621c7db. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

