### PR TITLE
Add edleeman.co.uk, blog.mattsbit.co.uk, shawnhoover.dev

### DIFF
--- a/smallweb.txt
+++ b/smallweb.txt
@@ -5259,6 +5259,7 @@ https://blog.matthewskelton.net/feed
 https://blog.mattnigh.net/rss
 https://blog.mattpalmer.io/feed
 https://blog.mattrbianchi.com/index.xml
+https://blog.mattsbit.co.uk/index.xml
 https://blog.maxg.io/rss
 https://blog.maxgio.me/index.xml
 https://blog.maximeheckel.com/rss.xml
@@ -10199,6 +10200,7 @@ https://edithsstreets.blogspot.com/feeds/posts/default
 https://editions64k.fr/atom
 https://edjiang.com/feed
 https://edjohnsonwilliams.co.uk/rss.xml
+https://edleeman.co.uk/index.xml
 https://edmar.sh/feed.xml
 https://edmcman.github.io/blog/rss
 https://edmonddantes.bearblog.dev/feed/
@@ -25049,6 +25051,7 @@ https://shavinpeiries.com/rss
 https://shawenyao.com/feed.xml
 https://shawn.medero.net/feed.rss
 https://shawnharris.com/feed/atom
+https://shawnhoover.dev/notes/index.xml
 https://shawnhumphrey.com/feed
 https://shawnhymel.com/feed
 https://shawnmatthewcrawford.com/feeds/all.atom.xml


### PR DESCRIPTION
Adding three personal blogs:

- https://edleeman.co.uk/index.xml — personal blog, active (posts May 2026)
- https://blog.mattsbit.co.uk/index.xml — personal tech blog, active (posts April 2026)
- https://shawnhoover.dev/notes/index.xml — personal dev notes, active (posts March 2026)

All in English, no ads, no NSFW, single-author. Entries inserted in alphabetical order.