### PR TITLE
Add new RSS feed links

### DIFF
--- a/smallweb.txt
+++ b/smallweb.txt
@@ -8354,7 +8354,6 @@ https://curvise.online/feed/?type=rss
 https://cushychicken.github.io/feed.xml
 https://cutebouncingbunnies.wordpress.com/feed
 https://cutiecove.gay/atom
-https://cutlefish.substack.com/feed
 https://cutter.re/index.xml
 https://cutting.io/feed.xml
 https://cvpcs.org/feed.php
@@ -15471,6 +15470,7 @@ https://jonathanspyer.com/feed
 https://jonathanturley.org/feed/
 https://jonathanwarden.com/index.xml
 https://jonathanweisberg.org/index.xml
+https://jonathanyeong.com/rss.xml
 https://jonathas.com/feed.xml
 https://jonayre.uk/blog/rss
 https://jonblack.gg/index.xml

--- a/smallweb.txt
+++ b/smallweb.txt
@@ -8354,6 +8354,7 @@ https://curvise.online/feed/?type=rss
 https://cushychicken.github.io/feed.xml
 https://cutebouncingbunnies.wordpress.com/feed
 https://cutiecove.gay/atom
+https://cutlefish.substack.com/feed
 https://cutter.re/index.xml
 https://cutting.io/feed.xml
 https://cvpcs.org/feed.php
@@ -12883,6 +12884,7 @@ https://guilhermealbert.com/feed.xml
 https://guilhermesimoes.github.io/feed.xml
 https://guillaume.baierouge.fr/atom.xml
 https://guillaumebriday.fr/articles.xml
+https://guillaumelouvel.com/rss.xml
 https://guillaumepaumier.com/rss.xml
 https://guillaumeslizewicz.com/index.xml
 https://guillego.com/atom.xml
@@ -17151,6 +17153,7 @@ https://lets-address-this-with-qasim-rashid.ghost.io/rss
 https://lets.re/blog/atom.xml
 https://letsdebug.it/index.xml
 https://letsmeetin.space/index.xml
+https://letters.draft.nu/rss
 https://letterformarchive.org/news/feed
 https://letterpressworkers.org/feed
 https://letters-to-myself.bearblog.dev/atom.xml


### PR DESCRIPTION
Added new RSS feed links to smallweb.txt.

## Checklist
- [x] I have read the [guidelines](https://github.com/kagisearch/smallweb/blob/main/README.md#%EF%B8%8F-guidelines-for-site-inclusion-to-the-list-%EF%B8%8F)

Also if submitting your own website you must add at least 2 other sites that are not yours (and are not in list yet) in the same commit:
1. https://cutlefish.substack.com/feed
2. https://letters.draft.nu/rss
