### PR TITLE
Add new RSS feeds to smallweb.txt

### DIFF
--- a/smallweb.txt
+++ b/smallweb.txt
@@ -1244,6 +1244,7 @@ https://abuisman.com/feed.xml
 https://abulman.co.uk/feed
 https://abuseofnotation.github.io/feed.xml
 https://abyssdomain.expert/@filippo.rss
+https://abyss.fish/thoughts.atom
 https://acai.sh/blog/rss.xml
 https://acairns.co.uk/rss.xml
 https://acalustra.com/rss.xml
@@ -18098,6 +18099,7 @@ https://mantrabeeg.bearblog.dev/atom.xml
 https://manu.show/feed.xml
 https://manu.zone/index.xml
 https://manualdousuario.net/en/feed
+https://manualcoffeebrewing.com/feed/
 https://manuarora.in/feed.xml
 https://manuel-strehl.de/feed.xml
 https://manuel.bernhardt.io/index.xml
@@ -27615,6 +27617,7 @@ https://thewrittenaddiction.com/feed
 https://theyhack.me/feed
 https://thezbook.com/rss.xml
 https://thezvi.wordpress.com/feed
+https://thiagorls.com/feed.xml
 https://thiagowfx.github.io/index.xml
 https://thibautbarrere.com/rss.xml
 https://thice.nl/atom


### PR DESCRIPTION
Adds 3 personal blogs, including my own (thiagorls.com) and 2 others I read regularly. All are single-author, in English, ad-free, and have posts within the last 12 months.

## Checklist
- [ ] I have read the [guidelines](https://github.com/kagisearch/smallweb/blob/main/README.md#%EF%B8%8F-guidelines-for-site-inclusion-to-the-list-%EF%B8%8F)

Also if submitting your own website you must add at least 2 other sites that are not yours (and are not in list yet) in the same commit:
1. https://abyss.fish/thoughts.atom
2. https://manualcoffeebrewing.com/feed/
