### PR TITLE
Add alexchernysh.com, christianfei.com, avinash.com.np

### DIFF
--- a/smallweb.txt
+++ b/smallweb.txt
@@ -1872,6 +1872,7 @@ https://alexcarpenter.me/notes/rss.xml
 https://alexcastle.net/atom
 https://alexcatalanflores.com/rss
 https://alexcbecker.net/feed.xml
+https://alexchernysh.com/rss.xml
 https://alexcodesart.com/rss
 https://alexcwatt.com/feed.xml
 https://alexdanco.com/feed
@@ -3224,6 +3225,7 @@ https://avidandrew.com/feed/index.xml
 https://aviewfromthecyclepath.com/atom.xml
 https://avikdas.com/feed.xml
 https://avilpage.com/rss.xml
+https://avinash.com.np/index.xml
 https://avinashv.net/rss.xml
 https://avisingh599.github.io/feed.xml
 https://avivace.com/index.xml
@@ -7464,6 +7466,7 @@ https://christian.kellner.me/feed
 https://christianchristiansen.net/rss.xml
 https://christiancommentmoiraredmond.blogspot.com/feeds/posts/default
 https://christiandewein.com/feed.xml
+https://christianfei.com/rss.xml
 https://christianfscott.com/index.xml
 https://christianheilmann.com/feed
 https://christianjung.com/atom


### PR DESCRIPTION
Adds three personal blog feeds in alphabetical position.

- **https://alexchernysh.com/rss.xml** — own site. Personal blog on applied AI systems, retrieval, evals, integration architecture. English, single author (Alex Chernysh), no ads/affiliates/popups, latest post within 12 months.
- **https://avinash.com.np/index.xml** — Avinash Pandey's personal developer blog. English, single author, no ads/affiliates/popups, latest post within 12 months.
- **https://christianfei.com/rss.xml** — Christian Fei's personal blog on programming and DIY. English, single author, no ads/affiliates/popups, latest post within 12 months.

All three placed in sorted positions in `smallweb.txt` per existing convention.

Per the README rule for self-submissions: at least 2 other personal blogs are added in the same commit.