### PR TITLE
Add blogs to smallweb.txt

### DIFF
--- a/smallweb.txt
+++ b/smallweb.txt
@@ -14427,6 +14427,7 @@ https://ivyswell-tavern.neocities.org/RSS_feeds/updates.xml
 https://iwannacrawlinwithyou.bearblog.dev/feed
 https://iwebthings.jenett.org/feed.atom
 https://iwebthings.joejenett.com/feed.atom
+https://iwhalen.com/feed_rss_updated.xml
 https://iwilldare.com/feed
 https://iwillneverbehappy.neocities.org/feed.xml
 https://iwriteaboutcode.blogspot.com/atom.xml
@@ -21323,6 +21324,7 @@ https://op111.net/feed.xml
 https://open-innovations.org/blog/rss
 https://open-source-ward.com/rss
 https://open-web-advocacy.org/feed.xml
+https://openai-sucks.bearblog.dev/feed
 https://openaircollective.com/feed/atom
 https://openbenches.org/atom
 https://opencv.md/index.xml
@@ -27036,6 +27038,7 @@ https://telerobotics.blogspot.com/feeds/posts/default
 https://telescoper.blog/atom
 https://teletext.zaibatsutel.net/rss
 https://telkins.dev/feed.xml
+https://telliamedrevisited.wordpress.com/feed
 https://telmo.dev/index.xml
 https://temikus.net/feed
 https://temochka.com/feed.xml


### PR DESCRIPTION
## Checklist
- [x] I have read the [guidelines](https://github.com/kagisearch/smallweb/blob/main/README.md#%EF%B8%8F-guidelines-for-site-inclusion-to-the-list-%EF%B8%8F)

Also if submitting your own website you must add at least 2 other sites that are not yours (and are not in list yet) in the same commit:
1. openai-sucks.bearblog.dev/
2. telliamedrevisited.wordpress.com/
