### PR TITLE
Update URL for casgit blog

### DIFF
--- a/smallweb.txt
+++ b/smallweb.txt
@@ -7062,7 +7062,7 @@ https://casey.link/atom/articles
 https://caseyhandmer.wordpress.com/feed
 https://caseysoftware.com/feed
 https://casfy.bearblog.dev/atom.xml
-https://casgit.neocities.org/feed.xml
+https://casgit.com/feed.xml
 https://cashmere.rs/atom.xml
 https://casju0.bearblog.dev/atom.xml
 https://casnocha.com/feed


### PR DESCRIPTION
As the owner, the domain was updated.
It is no longer using neocities.
The old site points to the new site.

## Checklist
- [X] I have read the [guidelines](https://github.com/kagisearch/smallweb/blob/main/README.md#%EF%B8%8F-guidelines-for-site-inclusion-to-the-list-%EF%B8%8F)
