### PR TITLE
Add 4 blogs to smallweb.txt

### DIFF
--- a/smallweb.txt
+++ b/smallweb.txt
@@ -2271,6 +2271,7 @@ https://analog-antiquarian.net/feed/rss
 https://analog-gaming.de/index.xml
 https://analogbit.com/feed.xml
 https://analogdreams.zip/feed.xml
+https://analogfeelings.xyz/rss.xml
 https://analoghobbyist.bearblog.dev/atom
 https://analogist.net/index.xml
 https://analognowhere.com/feed/rss.xml
@@ -23900,6 +23901,8 @@ https://rileytestut.com/feed.xml
 https://rin.io/feed
 https://ring.muhokama.fun/atom.xml
 https://rinzewind.org/blog-en/feeds/all.rss.xml
+https://riomc.cloud/resources/feeds/south-island-cabin.xml
+https://riomc.cloud/resources/feeds/tech-blog.xml
 https://rion.io/rss
 https://rioterm.com/blog/atom.xml
 https://riotghoulia.blogspot.com/feeds/posts/default
@@ -28927,6 +28930,7 @@ https://universaldiscoverymethodology.com/feed/atom
 https://universealacarte.blogspot.com/feeds/posts/default?alt=rss
 https://univrsw3th4rt.blogspot.com/feeds/posts/default?alt=rss
 https://unix.dog/announcements.rss
+https://unix.dog/~yosh/blog/feed.atom
 https://unix.foo/index.xml
 https://unixbhaskar.wordpress.com/atom
 https://unixdigest.com/feed.rss


### PR DESCRIPTION
## Checklist
- [x] I have read the [guidelines](https://github.com/kagisearch/smallweb/blob/main/README.md#%EF%B8%8F-guidelines-for-site-inclusion-to-the-list-%EF%B8%8F)

Also if submitting your own website you must add at least 2 other sites that are not yours (and are not in list yet) in the same commit:
1. https://analogfeelings.xyz/rss.xml
2. https://riomc.cloud/resources/feeds/south-island-cabin.xml
3. https://riomc.cloud/resources/feeds/tech-blog.xml
4. https://unix.dog/~yosh/blog/feed.atom