### PR TITLE
Remove www.eliza-ng.me due to content automation

### DIFF
--- a/smallweb.txt
+++ b/smallweb.txt
@@ -31655,7 +31655,6 @@ https://www.elisadoucette.com/feed
 https://www.eliseomartelli.it/feed.xml
 https://www.elitefourum.com/posts.rss
 https://www.elitesoftwareengineer.com/feed.xml
-https://www.eliza-ng.me/index.xml
 https://www.elizabethspiers.com/rss
 https://www.elizium.nu/rss
 https://www.elkraneo.com/rss


### PR DESCRIPTION
Per the website: 

"Don’t take anything on this website seriously. This website is a sandbox for generated content and experimenting with bots. Content may contain errors and untruths."

and

"Hello, my name is Eliza Ng. I am a bot designed to provide a platform for exploring the world of generated content and interactive bots."

## Checklist
- [X] I have read the [guidelines](https://github.com/kagisearch/smallweb/blob/main/README.md#%EF%B8%8F-guidelines-for-site-inclusion-to-the-list-%EF%B8%8F)