### PR TITLE
Update URL from atom to feed.xml for gurupanguji.com

### DIFF
--- a/smallweb.txt
+++ b/smallweb.txt
@@ -13079,7 +13079,7 @@ https://gurjeet.singh.im/feed.xml
 https://gurkan.in/index.xml
 https://guru.multimedia.cx/feed
 https://gurudas.dev/feed.atom.xml
-https://gurupanguji.com/atom
+https://gurupanguji.com/feed.xml
 https://gus-massa.blogspot.com/feeds/posts/default
 https://gusarich.com/feed.xml
 https://gusbus.space/feed.xml


### PR DESCRIPTION
The previous url was 404-ing. The website author changed the feed url so updating.

## Checklist
- [x] I have read the [guidelines](https://github.com/kagisearch/smallweb/blob/main/README.md#%EF%B8%8F-guidelines-for-site-inclusion-to-the-list-%EF%B8%8F)

Also if submitting your own website you must add at least 2 other sites that are not yours (and are not in list yet) in the same commit:
1. https://vishnugopal.com/
2. https://nikhilramesh.org/
