### PR TITLE
Update smallweb.txt

### DIFF
--- a/smallweb.txt
+++ b/smallweb.txt
@@ -10644,7 +10644,7 @@ https://eggdev.neocities.org/Feed.xml
 https://eggerapps.at/blog/rss.xml
 https://eggfreckles.net/rss
 https://eggler.cyou/atom
-https://eghone.eu/atom
+https://eghone.eu/feed.xml
 https://egonelbre.com/index.xml
 https://egpu.io/feed
 https://egrasps.in/feed


### PR DESCRIPTION
Correction to the RSS feed link for the site https://eghone.eu : Instead of : https://eghone.eu/atom
Read: https://eghone.eu/feed.xml

## Checklist
- [ x] I have read the [guidelines](https://github.com/kagisearch/smallweb/blob/main/README.md#%EF%B8%8F-guidelines-for-site-inclusion-to-the-list-%EF%B8%8F)
