### PR TITLE
Remove outdated RSS feed link

### DIFF
--- a/smallweb.txt
+++ b/smallweb.txt
@@ -18031,7 +18031,6 @@ https://lightfoot.dev/rss
 https://lightfrom.space/rss
 https://lighthouse1212.com/feed.rss
 https://lighthousenewsletter.com/feed.xml
-https://lightlogged.bearblog.dev/feed/
 https://lightlogged.blog/feed/
 https://lightningwright.net/atom.xml
 https://lightsforcats.com/atom


### PR DESCRIPTION
Removed outdated/duplicated RSS feed link for lightlogged.bearblog.dev.

## Checklist
- [x] I have read the [guidelines](https://github.com/kagisearch/smallweb/blob/main/README.md#%EF%B8%8F-guidelines-for-site-inclusion-to-the-list-%EF%B8%8F)
