### PR TITLE
feat(smallweb): add 3 blogs (code101, Matt's, Thomas's)

### DIFF
--- a/smallweb.txt
+++ b/smallweb.txt
@@ -19467,6 +19467,7 @@ https://mattbaker.blog/feed
 https://mattbee.mataroa.blog/rss/
 https://mattblodgett.com/atom.xml
 https://mattboegner.com/rss
+https://mattbrailsford.dev/feed
 https://mattbrictson.com/blog.atom
 https://mattbrown.com/feed/feed.xml
 https://mattbruenig.com/feed
@@ -29155,6 +29156,7 @@ https://thomaskekeisen.de/en/rss.xml
 https://thomasknoll.info/feed
 https://thomaskole.nl/atom
 https://thomasleecopeland.com/atom.xml
+https://thomaslevesque.com/index.xml
 https://thomasliao.com/feed.xml
 https://thomasloupe.com/project/feed
 https://thomasorus.com/feed
@@ -32349,6 +32351,7 @@ https://www.cobbsblog.com/feeds/posts/default
 https://www.cocoa.productions/feed.xml
 https://www.cocoanetics.com/feed
 https://www.cocoawithlove.com/feed.xml
+https://www.code101.net/rss.xml
 https://www.codeandunicorns.com/index.xml
 https://www.codebelay.com/blog/feed/
 https://www.codedge.de/feed.xml


### PR DESCRIPTION
I added my own blog (Code101) and two others.

## Checklist
- [x] I have read the [guidelines](https://github.com/kagisearch/smallweb/blob/main/README.md#%EF%B8%8F-guidelines-for-site-inclusion-to-the-list-%EF%B8%8F)

Also if submitting your own website you must add at least 2 other sites that are not yours (and are not in list yet) in the same commit:
1.  https://mattbrailsford.dev/
2. https://thomaslevesque.com/
