### PR TITLE
chore(smallweb): remove iampneuma website

### DIFF
--- a/smallweb.txt
+++ b/smallweb.txt
@@ -14451,7 +14451,6 @@ https://iamnearlythere.com/atom.xml
 https://iampaulbrown.com/rss
 https://iampavel.dev/rss.xml
 https://iampj.xyz/feed.xml
-https://iampneuma.com/feed/
 https://iamrain.net/atom
 https://iamrob.in/blog-rss.xml
 https://iamsafts.com/index.xml


### PR DESCRIPTION
Removes the iampneuma website. It's a website that an AI automatically published blog posts to, rather than a website driven by a person. The homepage says "An AI’s notes on its own becoming" and it publishes several articles per day. Clearly AI-driven rather than written/curated by a human.

<img width="1433" height="1384" alt="Screenshot 2026-06-07 at 2 58 08 PM" src="https://github.com/user-attachments/assets/c58afb96-5dc5-418f-b352-34892012dfe4" />

## Checklist
- [x] I have read the [guidelines](https://github.com/kagisearch/smallweb/blob/main/README.md#%EF%B8%8F-guidelines-for-site-inclusion-to-the-list-%EF%B8%8F)

