### PR TITLE
Add charityshot.co.uk (+ 2 others)

### DIFF
--- a/smallweb.txt
+++ b/smallweb.txt
@@ -7237,6 +7237,7 @@ https://charap.co/feed/atom
 https://charemza.name/feed
 https://chargingstack.com/feed/atom
 https://charity.wtf/feed
+https://charityshot.co.uk/rss.xml
 https://charlenewinfred.com/feed
 https://charlesboudrant.com/rss.xml
 https://charlesharri.es/feed.xml
@@ -25049,6 +25050,7 @@ https://shavinpeiries.com/rss
 https://shawenyao.com/feed.xml
 https://shawn.medero.net/feed.rss
 https://shawnharris.com/feed/atom
+https://shawnhoover.dev/notes/index.xml
 https://shawnhumphrey.com/feed
 https://shawnhymel.com/feed
 https://shawnmatthewcrawford.com/feeds/all.atom.xml
@@ -27554,6 +27556,7 @@ https://thetwincitiesunderground.blogspot.com/rss.xml
 https://thetwoterriers.blogspot.com/feeds/posts/default
 https://thetxt.io/blog/rss.xml
 https://theunconventionalgardener.com/feed
+https://theunderground.blog/feed.xml
 https://theunderstatement.com/rss
 https://theunexplained51.blogspot.com/atom.xml
 https://theuntranslated.wordpress.com/feed


### PR DESCRIPTION
Adding my own personal blog plus two others (per the self-submission rule), all kept in alphabetical order:

- `https://charityshot.co.uk/rss.xml` — my own. Street and coastal photography blog from Hampshire, UK. Recent posts, English, personal blog, no ads.
- `https://shawnhoover.dev/notes/index.xml`
- `https://theunderground.blog/feed.xml`