### PR TITLE
Add new RSS feeds to smallweb.txt

### DIFF
--- a/smallweb.txt
+++ b/smallweb.txt
@@ -6306,6 +6306,7 @@ https://blog.veritates.love/rss.xml
 https://blog.vermeilsoft.com/atom.xml
 https://blog.vero.site/index.xml
 https://blog.veronika.skin/atom
+https://blog.vezpi.com/en/index.xml
 https://blog.vfiles.no/posts/index.xml
 https://blog.vghaisas.com/index.xml
 https://blog.videah.net/atom.xml
@@ -12589,6 +12590,7 @@ https://frederikcreemers.be/index.xml
 https://fredhohman.com/feed.xml
 https://fredkozlowski.com/feed
 https://fredlybrand.com/feed
+https://fredrickb.com/feed.xml
 https://fredrikaverpil.github.io/index.xml
 https://fredrikhertzberg.com/feed
 https://fredrikholmqvist.com/index.xml
@@ -33465,6 +33467,7 @@ https://www.geekrant.org/feed
 https://www.geekytidbits.com/rss.xml
 https://www.geepawhill.org/feed
 https://www.geero.net/feed
+https://www.geewiz.dev/rss.xml
 https://www.geirman.com/feed
 https://www.general-staff.com/atom
 https://www.generalreasoning.com/feed.xml


### PR DESCRIPTION
Add new RSS feeds to smallweb.txt

## Checklist
- [x] I have read the [guidelines](https://github.com/kagisearch/smallweb/blob/main/README.md#%EF%B8%8F-guidelines-for-site-inclusion-to-the-list-%EF%B8%8F)

Also if submitting your own website you must add at least 2 other sites that are not yours (and are not in list yet) in the same commit:
1. https://blog.vezpi.com/en/index.xml
2. https://www.geewiz.dev/rss.xml
