### PR TITLE
Add new blog feed URLs to smallweb.txt

### DIFF
--- a/smallweb.txt
+++ b/smallweb.txt
@@ -61,6 +61,7 @@ http://bholley.net/feed.xml
 http://bilalquadri.com/feed.xml
 http://birdmilkcafe.com/feed
 http://bitfission.com/atom.xml
+http://bitflipping.net/posts_feed
 http://bitmason.blogspot.com/atom.xml
 http://bitterteaandmystery.blogspot.com/atom.xml
 http://blog.a-eon.biz/blog/index.php/feed
@@ -144,6 +145,7 @@ http://brianstorms.com/atom.xml
 http://brtmr.de/feed.xml
 http://bryan-murdock.blogspot.com/atom.xml
 http://bryank.im/feed
+http://bryantcodes.art
 http://bryukh.com/feed.xml
 http://bslabs.net/feed.xml
 http://bureboyblog.blogspot.com/atom.xml
@@ -368,6 +370,7 @@ http://jackkelly.name/blog/atom.xml
 http://jackywoo.cn/feed
 http://james-simon.github.io/feed.xml
 http://jaredeast.com/feed
+http://javiermorales.dev/
 http://jbalogh.me/atom.xml
 http://jeff-barr.com/feed.xml
 http://jelenadobric.com/blog-1?format=rss


### PR DESCRIPTION
Added new feed URLs for various blogs and websites.

## Checklist
- [x] I have read the [guidelines](https://github.com/kagisearch/smallweb/blob/main/README.md#%EF%B8%8F-guidelines-for-site-inclusion-to-the-list-%EF%B8%8F)

Also if submitting your own website you must add at least 2 other sites that are not yours (and are not in list yet) in the same commit:
1. http://bryantcodes.art
2. http://javiermorales.dev/
