### PR TITLE
Add new feed URL for robingood.substack.com

### DIFF
--- a/smallweb.txt
+++ b/smallweb.txt
@@ -25243,6 +25243,7 @@ https://robinbakker.nl/feed.xml
 https://robinbb.com/index.xml
 https://robindoherty.com/feed.xml
 https://robindouglas.org/atom
+https://robingood.substack.com/feed.xml
 https://robinharford.com/feed
 https://robinmetral.com/feed.xml
 https://robinrendle.com/cascadefeed.xml


### PR DESCRIPTION
Insights, strategies, trends, tools and resources about building authority, credibility and trust for experts, advisors, journalists

## Checklist
- [ ] I have read the [guidelines](https://github.com/kagisearch/smallweb/blob/main/README.md#%EF%B8%8F-guidelines-for-site-inclusion-to-the-list-%EF%B8%8F)

Also if submitting your own website you must add at least 2 other sites that are not yours (and are not in list yet) in the same commit:
1. https://www.creativedestruction.club/feed.xml
2. https://sceniusmag.substack.com/feed.xml
