### PR TITLE
Remove siliconopera.com (multi-author AI content farm)

### DIFF
--- a/smallweb.txt
+++ b/smallweb.txt
@@ -26886,7 +26886,6 @@ https://siliconhillslawyer.com/atom
 https://siliconislandblog.wordpress.com/feed
 https://siliconjunction.wordpress.com/feed/atom
 https://silicononyx.com/feed.xml
-https://siliconopera.com/feed/
 https://silky.bearblog.dev/index.xml
 https://silliest.website:3/blog/rss.xml
 https://silly.business/index.xml


### PR DESCRIPTION
## Remove a site

Removing `https://siliconopera.com/feed/`.

### Guidelines it breaks

**1. "Only personal blogs may be submitted (no multi-author blogs)."**
This is definitely not a personal blog. It has multiple authors. All of them looking fake. They point to broken or incorrect twitter handles. Like fake Jordan: [@jordanrivera_vc](https://twitter.com/jordanrivera_vc)

**2. "No auto generated, LLM generated or spam content."**
The content is machine-generated at non-human scale. The "Marcus Webb" author page alone lists **188 articles**, including seven near-duplicate SEO rewrites of a single idea:
- "Why the Second-Place Tech Company Prints More Money"
- "Second Place in Tech Is Usually the Profit Winner"
- "The Second-Biggest Tech Company Is Usually the Richest"
- "Why the Runner-Up in Tech Often Makes More Money"
- "Why Second Place in Tech Often Profits More Than First"
- "Why the Second-Place Company Usually Makes More Money"
- "The Second-Most-Popular Product Almost Always Wins on Profit"

### Evidence
A recent post, ["The Customer Who Almost Killed Slack, Stripe, and Airbnb"](https://siliconopera.com/the-customer-who-almost-killed-slack-stripe-and-airbnb/), was flagged on Hacker News as fabricated AI content: https://news.ycombinator.com/item?id=48678820

From that thread:
> "The author is not even a real person, none of them on this 'publication' are. They didn't even bother correcting the hallucinated Twitter handles."

The piece recounts confident, specific anecdotes about Airbnb, Slack, and Stripe (e.g. exact early revenue figures) with no sources, links, or attribution.

- [x] I have read the [guidelines](https://github.com/kagisearch/smallweb/blob/main/README.md#%EF%B8%8F-guidelines-for-site-inclusion-to-the-list-%EF%B8%8F)
