### PR TITLE
Removed vanzasetia.xyz for containing transphobic content

### DIFF
--- a/smallweb.txt
+++ b/smallweb.txt
@@ -30690,7 +30690,6 @@ https://vanten-s.com/index.xml
 https://vantucker.com/feed
 https://vanwa.ch/index.xml
 https://vanwilgenburg.wordpress.com/feed
-https://vanzasetia.xyz/feed.xml
 https://vaporwave-van-gogh.tumblr.com/rss
 https://varaneckas.com/rss.xml
 https://varanios.com/feed.rss


### PR DESCRIPTION
see https://github.com/kagisearch/smallweb/issues/805
transphobic content doesn't belong in a smallweb list

## Checklist
- [x] I have read the [guidelines](https://github.com/kagisearch/smallweb/blob/main/README.md#%EF%B8%8F-guidelines-for-site-inclusion-to-the-list-%EF%B8%8F)