### PR TITLE
Add bluee.gg, everygame, and peaks and nulls

### DIFF
--- a/smallweb.txt
+++ b/smallweb.txt
@@ -237,6 +237,7 @@ http://erenon.hu/posts/index.xml
 http://esr.ibiblio.org/?feed=rss2
 http://evanfields.net/feed.xml
 http://everydayislikewednesday.blogspot.com/feeds/posts/default
+http://everygame.tumblr.com/rss
 http://exploits.run/feed.xml
 http://fabriq.fm/feed
 http://faughnan.blogspot.com/atom.xml
@@ -6532,6 +6533,7 @@ https://bluebones.net/feed
 https://bluebottles.bearblog.dev/atom
 https://bluecapsicum.tumblr.com/rss
 https://bluechinchompa.com/all.rss
+https://bluee.gg/feed.xml
 https://bluelabyrinths.com/feed
 https://bluelander.bearblog.dev/feed
 https://bluelemonbits.com/feed/atom
@@ -23306,6 +23308,7 @@ https://peadarcoyle.wordpress.com/feed
 https://peak35.com/index.xml
 https://peaklevs.com/feed.xml
 https://peakprosperity.com/feed/atom
+https://peaksandnulls.net/index.php/feed/
 https://peanball.net/index.xml
 https://pearsonified.com/feed
 https://peateasea.de/feed.xml


### PR DESCRIPTION
Self-submission of my personal site plus two other personal blogs not previously listed, per the contribution guidelines.

- https://bluee.gg/feed.xml — Blue Egg, a personal electronic/techno music project from Los Angeles. Single author (Grant Goddard), English, ad-free, no popups, recent posts.
- http://everygame.tumblr.com/rss — "everyone every game," a personal blog writing essays on video games. Single author, English, ad-free.
- https://peaksandnulls.net/index.php/feed/ — "peaks and nulls," a personal blog on modular synthesis. Single author, English, ad-free.

All three added in their alphabetical positions in smallweb.txt.