### PR TITLE
Add aaronmassicotte.com (plus two more feeds)

### DIFF
--- a/smallweb.txt
+++ b/smallweb.txt
@@ -462,6 +462,7 @@ http://martyromero.me/atom.xml
 http://massivegreatness.com/feed
 http://mathtourist.blogspot.com/feeds/posts/default
 http://matthiasnehlsen.com/atom.xml
+http://mcld.co.uk/blog/feeds/mcld_blog.rss
 http://measuredmass.com/atom
 http://meissereconomics.com/feed.xml
 http://melbourneblogger.blogspot.com/atom.xml
@@ -1136,6 +1137,7 @@ https://aalhour.com/feed
 https://aalonso.dev/blog/index.xml
 https://aalpar.github.io/feed
 https://aamirvirani.com/feed.xml
+https://aanandmadhav.com/feed.xml
 https://aangat.lahat.computer/automad/feed
 https://aaqa.dev/rss.xml
 https://aaqeastend.com/feed
@@ -1169,6 +1171,7 @@ https://aaronjz.com/feed.xml
 https://aaronland.info/orthis/feeds/atom.xml
 https://aaronlevin.ca/rss
 https://aaronlou.com/feed.xml
+https://aaronmassicotte.com/index.xml
 https://aaronmoodie.com/feed.xml
 https://aaronparecki.com/feed.xml
 https://aaronrandall.com/atom


### PR DESCRIPTION
Adding my personal blog feed https://aaronmassicotte.com/index.xml

Per the contributing guideline, this commit also adds two other feeds not already in the list:
- https://aanandmadhav.com/feed.xml
- http://mcld.co.uk/blog/feeds/mcld_blog.rss

All three are English-language, human-written personal sites with posts from within the last 12 months and no ads/affiliate content. Entries kept in sorted order.