### PR TITLE
Fix feed URL for mairamartins.com

### DIFF
--- a/smallweb.txt
+++ b/smallweb.txt
@@ -19361,7 +19361,7 @@ https://mainelymenswear.com/feed
 https://mainlymatmul.com/rss.xml
 https://maique.eu/feed.xml
 https://mairacanal.github.io/atom.xml
-https://mairamartins.com/atom.xml
+https://mairamartins.com/feed
 https://maiste.fr/rss.xml
 https://majabraumberger.com/rss.xml
 https://majantali.net/feed


### PR DESCRIPTION
My personal blog was already on the list but pointing at the wrong URL. I am not submitting additional sites as per #712 -- but also because every English-language blog on my rss reader is already on the list and it seems we can't submit international language ones.

## Checklist
- [x] I have read the [guidelines](https://github.com/kagisearch/smallweb/blob/main/README.md#%EF%B8%8F-guidelines-for-site-inclusion-to-the-list-%EF%B8%8F)

Also if submitting your own website you must add at least 2 other sites that are not yours (and are not in list yet) in the same commit:
1.
2.
