### PR TITLE
Add janilowski.pl (+2 others) to the smallweb list

### DIFF
--- a/smallweb.txt
+++ b/smallweb.txt
@@ -9279,6 +9279,7 @@ https://danielprindii.com/blog.rss
 https://danielpunkass.micro.blog/feed.xml
 https://danielquan.com/feed/
 https://danielraffel.me/rss
+https://danielrotter.at/feed.xml
 https://danielsada.tech/index.xml
 https://danielsaidi.com/feed.xml
 https://danielsieger.com/atom.xml
@@ -15820,6 +15821,7 @@ https://jani.isohanni.fi/rss/
 https://janicebakke.com/atom
 https://janika.bearblog.dev/feed/
 https://janikvonrotz.ch/index.xml
+https://janilowski.pl/rss/en.xml
 https://janitha.com/index.xml
 https://jank.bearblog.dev/feed/
 https://janko.io/feed.xml
@@ -23330,6 +23332,7 @@ https://paper.wf/binarycat/feed
 https://paperclipmaximizer.net/feed.xml
 https://paperclover.net/rss.xml
 https://paperless.blog/feed.xml
+https://paperpilot.dev/atom.xml
 https://paperpools.blogspot.com/atom.xml
 https://papers.vincy.dev/rss.xml
 https://papersplease.org/wp/feed


### PR DESCRIPTION
## Checklist
- [x] I have read the [guidelines](https://github.com/kagisearch/smallweb/blob/main/README.md#%EF%B8%8F-guidelines-for-site-inclusion-to-the-list-%EF%B8%8F)

Also if submitting your own website you must add at least 2 other sites that are not yours (and are not in list yet) in the same commit:
1. https://danielrotter.at/feed.xml
2. https://paperpilot.dev/atom.xml
