### PR TITLE
feat(smallweb): remove thomaskekeisen.de for having ads

### DIFF
--- a/smallweb.txt
+++ b/smallweb.txt
@@ -30006,7 +30006,6 @@ https://thomashodson.com/atom.xml
 https://thomashoneyman.com/index.xml
 https://thomashunter.name/feed.rss
 https://thomasjfrank.com/feed
-https://thomaskekeisen.de/en/rss.xml
 https://thomasknoll.info/feed
 https://thomaskole.nl/atom
 https://thomasleecopeland.com/atom.xml


### PR DESCRIPTION
Removed thomaskekeisen.de because the articles have ads in them, which violates one of the rules for inclusion in the small web index. Here is one example:

<img width="1610" height="1325" alt="Screenshot 2026-07-19 at 2 41 24 PM" src="https://github.com/user-attachments/assets/f769d318-81ba-4c71-863b-a437680de949" />

Which is from: https://kagi.com/smallweb/?url=https%3A%2F%2Fthomaskekeisen.de%2Fen%2Fblog%2Fevaluate-and-productionize-ai-generated-software

Another example:

<img width="1610" height="1325" alt="Screenshot 2026-07-19 at 2 46 00 PM" src="https://github.com/user-attachments/assets/e2c74228-16a1-4c25-bcf0-1755fbb4cd16" />

Which was from the direct link: https://thomaskekeisen.de/en/blog/evaluate-and-productionize-ai-generated-software/