### PR TITLE
Update blog feed URLs in smallweb.txt

### DIFF
--- a/smallweb.txt
+++ b/smallweb.txt
@@ -113,6 +113,7 @@ http://blog.rburchell.com/feed.xml
 http://blog.reasonablycorrect.com/feed
 http://blog.richardweiss.org/feed.xml
 http://blog.rickumali.com/feeds/posts/default
+https://blog.rubenwardy.com/feed.xml
 http://blog.sheasilverman.com/feed
 http://blog.sigfpe.com/atom.xml
 http://blog.sqisland.com/feeds/posts/default
@@ -456,7 +457,6 @@ http://manuelmoreale.com/feed.xml
 http://maple.pet/blog.atom
 http://marcobonvini.com/feed.xml
 http://marcosh.github.io/feed.xml
-https://www.marginalia.nu/log/index.xml
 http://mark---lawrence.blogspot.com/atom.xml
 http://markBernstein.org/news.rss
 http://markbivens.com/m/feed


### PR DESCRIPTION
Added a new feed URL for Rubenwardy's blog and removed a duplicate feed URL.

## Checklist
- [x] I have read the [guidelines](https://github.com/kagisearch/smallweb/blob/main/README.md#%EF%B8%8F-guidelines-for-site-inclusion-to-the-list-%EF%B8%8F)

As a complement of #840, I have removed Viktor's blog which was already there and instead added ruben's blog.