### PR TITLE
Add nested.blog, esben.jp & Canned Dragons to smallweb.txt

### DIFF
--- a/smallweb.txt
+++ b/smallweb.txt
@@ -7203,6 +7203,7 @@ https://cangshui.net/feed
 https://canicula.com/wp/feed/
 https://canines.neocities.org/feed.xml
 https://canion.blog/feed.xml
+https://canneddragons.pagecord.com/feed.xml
 https://cannon.bearblog.dev/feed/
 https://cannonalexander.writeas.com/feed
 https://canolcer.eu/feed
@@ -11112,6 +11113,7 @@ https://erysdren.me/atom.xml
 https://es617.dev/feed
 https://es617.github.io/feed.xml
 https://esafev.com/rss.xml
+https://esben.jp/feed
 https://esbueno.noahstokes.com/rss/rss.feed
 https://escapeadulthood.com/feed/
 https://eschatologist.net/blog/?feed=rss2
@@ -20930,6 +20932,7 @@ https://nervuri.net/feed.atom
 https://nesbitt.io/feed.xml
 https://nesdoug.com/atom
 https://nest.jakl.one/microposts/feed.xml
+https://nested.blog/feeds/blog.xml
 https://nestenius.se/feed
 https://netapinotes.com/rss
 https://netboot.xyz/blog/atom.xml


### PR DESCRIPTION
## Checklist
- [x] I have read the [guidelines](https://github.com/kagisearch/smallweb/blob/main/README.md#%EF%B8%8F-guidelines-for-site-inclusion-to-the-list-%EF%B8%8F)

Also if submitting your own website you must add at least 2 other sites that are not yours (and are not in list yet) in the same commit:
1. esben.jp
2. www.canneddragons.net
3. My own: nested.blog
