### PR TITLE
feat: add Cloud Run startup and liveness probes

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -171,3 +171,6 @@ app/data
 
 # Editor backup files
 *~
+
+# macOS
+.DS_Store

--- a/app/sw.py
+++ b/app/sw.py
@@ -2022,6 +2022,44 @@ def opml():
     return Response(opml_cache, mimetype="text/x-opml+xml")
 
 
+# Cloud Run probe endpoints. Registered without the URL prefix because the
+# probes talk to the container port directly, not through the kagi.com proxy.
+# Both are intentionally contentless -- the deployment is
+# --allow-unauthenticated, so the run.app URL exposes them publicly.
+
+
+@app.route("/readyz")
+def readyz():
+    """Startup gate: 503 until this instance has feeds it can serve.
+
+    Every feed is fetched at import time, and gunicorn's master binds the port
+    before the worker gets that far, so a TCP probe passes on an instance that
+    is still minutes away from serving a post. `urls_cache` is the cache every
+    mode falls back to, so having it is what "ready" means.
+    """
+    if not urls_cache:
+        return Response("feeds not loaded\n", status=503, mimetype="text/plain")
+    return Response("ok\n", mimetype="text/plain")
+
+
+@app.route("/healthz")
+def healthz():
+    """Liveness: 503 once the gcsfuse data mount has gone away.
+
+    gcsfuse_run.sh daemonizes gcsfuse, so a mount that dies after startup
+    leaves this process happily serving reads while every like, note and flag
+    write fails into a swallowed exception. A dead FUSE daemon leaves the
+    mountpoint in place but fails stat() with ENOTCONN, which is the cheapest
+    signal available: one syscall, no GCS round trip.
+    """
+    try:
+        os.stat(DIR_DATA)
+    except OSError as e:
+        logger.error("healthz: data dir %s is unusable: %s", DIR_DATA, e)
+        return Response("data unavailable\n", status=503, mimetype="text/plain")
+    return Response("ok\n", mimetype="text/plain")
+
+
 time_saved_likes = datetime.now()
 time_saved_notes = datetime.now()
 time_saved_flagged_content = datetime.now()

--- a/app/tests/test_health.py
+++ b/app/tests/test_health.py
@@ -1,0 +1,50 @@
+"""Cloud Run probe endpoints.
+
+The deploy points its startup probe at /readyz and its liveness probe at
+/healthz, so each has to actually fail for the condition it exists to catch:
+feeds not loaded yet, and a gcsfuse data mount that has gone away. A probe that
+can only ever return 200 is just a TCP check with extra steps.
+"""
+import os
+import re
+
+APP_DIR = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
+REPO_DIR = os.path.dirname(APP_DIR)
+
+
+def test_readyz_ok_once_feeds_are_loaded(client):
+    assert client.get("/readyz").status_code == 200
+
+
+def test_readyz_503_before_feeds_load(app_module, client):
+    # What an instance looks like while the import-time fetches are still
+    # running: port bound, no post it could serve.
+    app_module.urls_cache = []
+    assert client.get("/readyz").status_code == 503
+
+
+def test_healthz_ok_when_data_dir_is_reachable(client):
+    assert client.get("/healthz").status_code == 200
+
+
+def test_healthz_503_when_data_dir_is_unreachable(app_module, client, monkeypatch):
+    # A dead gcsfuse daemon fails stat() with ENOTCONN; an absent path fails it
+    # with ENOENT. The handler treats every OSError alike, so pointing at a
+    # missing path drives the real code path without faking out os.stat.
+    monkeypatch.setattr(app_module, "DIR_DATA", "/nonexistent/smallweb-data")
+    assert client.get("/healthz").status_code == 503
+
+
+def test_probe_paths_in_cloudbuild_are_registered_routes(app_module):
+    """A renamed route would make every instance fail its startup probe.
+
+    Cloud Run treats a 404 from a startup probe as a failure, so a drifted path
+    here does not degrade the service -- it stops the revision from ever going
+    live.
+    """
+    with open(os.path.join(REPO_DIR, "cloudbuild.yaml"), encoding="utf-8") as handle:
+        probe_paths = set(re.findall(r"httpGet\.path=([^,'\"]+)", handle.read()))
+
+    assert probe_paths, "found no probe paths in cloudbuild.yaml"
+    registered = {rule.rule for rule in app_module.app.url_map.iter_rules()}
+    assert probe_paths <= registered, f"not routed: {sorted(probe_paths - registered)}"

--- a/cloudbuild.yaml
+++ b/cloudbuild.yaml
@@ -18,7 +18,13 @@ steps:
       '--cpu=1',
       '--memory=1Gi',
       '--min-instances', '2',
-      '--max-instances', '4'
+      '--max-instances', '4',
+      # Startup budget of 220s (under Cloud Run's 240s ceiling) covers the
+      # worst case for the import-time feed fetches in sw.py.
+      '--startup-probe', 'httpGet.path=/readyz,httpGet.port=8080,periodSeconds=10,timeoutSeconds=5,failureThreshold=22',
+      # Deliberately slack: one gunicorn worker also runs the 5-minute feed
+      # refresh, so a tight probe would restart healthy instances mid-parse.
+      '--liveness-probe', 'httpGet.path=/healthz,httpGet.port=8080,periodSeconds=30,timeoutSeconds=10,failureThreshold=3'
     ]
 images:
   - us-central1-docker.pkg.dev/${PROJECT_ID}/${_ARTIFACT_REGISTRY_REPO}/smallweb:${SHORT_SHA}


### PR DESCRIPTION
Refs [INFRA-1700](https://linear.app/kagi/issue/INFRA-1700/reconfigure-the-health-check-for-the-deployment)

## Problem

`cloudbuild.yaml` configured no probes at all, so Cloud Run fell back to its default TCP startup probe and no liveness probe. Three things were wrong:

**The TCP startup probe was misleading.** `gcsfuse_run.sh:31` runs gunicorn without `--preload`, so the master binds `0.0.0.0:$PORT` before forking the worker that imports `sw.py`. That import does 5 sequential `requests.get(..., timeout=30)` plus an embeddings fetch and a numpy matrix build (`sw.py:2056-2059`) — up to ~180s worst case. The TCP probe passed in under a second, so with `--min-instances 2` a new revision was marked healthy and took traffic while both instances were still cold.

**`/` is not a usable health signal.** `sw.py:1214-1219` returns HTTP 200 with a `feed_unavailable=True` page when every cache is empty, so a probe pointed there reports healthy on a data-less instance.

**A dead gcsfuse mount was invisible.** `gcsfuse_run.sh:23` daemonizes gcsfuse and `set -e` only catches failure at mount time. If the daemon dies later, `/app/data` goes stale and every write fails into a swallowed except (`sw.py:1649`, `sw.py:1683`, `sw.py:2077-2090`) — the instance serves reads forever while silently losing every like, note and flag.

## Change

- `GET /readyz` — 200 once `urls_cache` is populated, else 503. It's the cache every mode falls back to, so having it is what "ready" means. Startup-probe target.
- `GET /healthz` — 200 if `os.stat(DIR_DATA)` succeeds, 503 on `OSError`. A dead FUSE daemon leaves the mountpoint in place but fails `stat()` with `ENOTCONN`; one syscall, no GCS round trip. Liveness target.

Both registered without the URL prefix — probes hit the container port directly, not the kagi.com proxy.

Probe timings are deliberate. Startup budget is 10s x 22 = 220s, under Cloud Run's 240s ceiling and enough for the worst-case import. Liveness is slack (30s period, 3 failures = 90s to restart) because the single gunicorn worker also runs the 5-minute feed refresh on a background thread; a tight probe would restart healthy instances mid-parse.

## Trade-off to review

Putting the mount check in **liveness** turns a bucket outage into a restart loop rather than a silently-degraded service. I think that's right — writes are already being lost in that state — but the conservative alternative is moving the `os.stat` check to `/readyz` and alerting instead of restarting. Two-line change if you'd prefer that.

## Scope note

The card was filed off an uptime monitor hitting `https://kagi.com/smallweb/` and seeing HTTP 500. This PR fixes the *Cloud Run* probes; it does not retarget that external monitor. Because the new routes are un-prefixed, they are **not** reachable at `kagi.com/smallweb/healthz`. If part of the intent is to point the uptime check at a real readiness endpoint, that needs the prefixed route variants too — say so and I'll add them.

## Testing

`app/tests/test_health.py` — 5 tests: both 200 paths, both 503 paths, and a guard tying the `httpGet.path` values in `cloudbuild.yaml` to Flask's `url_map` (a drifted path there doesn't degrade the service, it stops the revision from ever going live).

- **52 passed** (47 pre-existing + 5 new).
- **Mutation-checked**: removing the `urls_cache` guard and pointing `os.stat` at `"."` makes exactly the two 503 tests fail, so they can fail.
- **Probe flags validated** against the supported key set from `gcloud run deploy --help` (SDK 575.0.1): no unsupported keys, startup budget under 240s, liveness `timeoutSeconds` <= `periodSeconds`.

## Not addressed

Adjacent findings left alone deliberately: `--no-cpu-throttling` is still unset, so the 5-minute APScheduler jobs remain throttled between requests on the min-instances (the liveness probe's 30s traffic will now partly mask this); `--cpu-boost` would cut the slow import, as would moving `update_embeddings()` off the import path; and the comment at `gcsfuse_run.sh:30` claims the worker timeout is 0 while line 31 passes `-t 100`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)