### PR TITLE
fix: keep ?comic in river card links so they resolve to the comic

### DIFF
--- a/app/sw.py
+++ b/app/sw.py
@@ -1493,6 +1493,8 @@ def river():
             sw_params["yt"] = ""
         elif mode == "gh":
             sw_params["gh"] = ""
+        elif mode == "comic":
+            sw_params["comic"] = ""
         sw_url = prefix + "/?" + urlencode(sw_params)
         cards.append({
             "link": entry.link,


### PR DESCRIPTION
Hi. I noticed that river entries for comics linked to /?url=<post> with no comic flag, so the index route fell back to the blog cache and picked a random blog post instead of the requested comic. I tried yt + gh as well but they were unaffected (they had explicit branches).

For example:

>https://kagi.com/smallweb/?url=https%3A%2F%2Fsofties.net%2Fcomic%2Fbook2-6%2Fi-dont-think-its-supposed-to-come-back-page-5%2F resolved to https://www.ianvisits.co.uk/articles/tickets-alert-national-theatre-to-host-a-sale-of-stage-props-91401/, when https://kagi.com/smallweb/?url=https%3A%2F%2Fsofties.net%2Fcomic%2Fbook2-6%2Fi-dont-think-its-supposed-to-come-back-page-5%2F&comic= resolves to the actual intended comic.

<img width="1288" height="792" alt="image" src="https://github.com/user-attachments/assets/4f575b65-e018-448c-9424-534289d4398e" />

I fixed it by adding the missing comic branch to the sw_url builder, matching the yt and gh branches. I tested it on a local dev server as well.