### PR TITLE
Remove css-tip.com feed URL

### DIFF
--- a/smallweb.txt
+++ b/smallweb.txt
@@ -11114,7 +11114,6 @@ https://csperkins.org/feed-all.atom
 https://css-articles.com/feed.xml
 https://css-irl.info/rss.xml
 https://css-plus.com/rss.xml
-https://css-tip.com/feed/feed.xml
 https://css.oddbird.net/feed.xml
 https://cssanalytics.wordpress.com/feed/
 https://csscade.com/feed.xml


### PR DESCRIPTION
Removed a site, for it contains ads. The site even sells the possibility to include your custom ad on it, bragging with tens of thousands of monthly views. 
