### PR TITLE
Remove non-compliant feed URLs from smallweb.txt

### DIFF
--- a/smallweb.txt
+++ b/smallweb.txt
@@ -10243,7 +10243,6 @@ https://classicalmusings.com/feed/
 https://classicalvalues.com/feed
 https://classicboombox.com/feed
 https://classicfilmandtvcorner.wordpress.com/atom
-https://classicnewyorkhistory.com/feed/
 https://classicsofsciencefiction.com/feed
 https://classicsofstrategy.com/feed/atom
 https://classidential.bearblog.dev/atom
@@ -40663,7 +40662,6 @@ https://www.charliemccarron.com/feed/
 https://www.charlz.net/feed.xml
 https://www.charpeni.com/blog/rss.xml
 https://www.chartewalk.com/index.xml
-https://www.cheapestdestinationsblog.com/feed/
 https://www.checkerboardhill.com/feed/
 https://www.cheehow.dev/blog/atom.xml
 https://www.cheerfulegg.com/feed/
@@ -43818,7 +43816,6 @@ https://www.mystaffordshirefigures.com/blog/feed
 https://www.mysteryfleshpitnationalpark.com/rss
 https://www.myteslaexperience.com/feed.xml
 https://www.mytungsten.net/feed.xml
-https://www.mywanderlust.pl/feed/atom/
 https://www.mywindphone.com/blog-feed.xml
 https://www.n00py.io/feed
 https://www.n10k.com/atom.xml


### PR DESCRIPTION
Removed travel blogs with undisclosed affiliate links and content farm characteristics

1. https://www.cheapestdestinationsblog.com/ (content farm with lots of undisclosed affiliate links for credit cards)
2. https://classicnewyorkhistory.com/ (LLM generated)
3. https://www.mywanderlust.pl/ (undisclosed affiliate links)