### PR TITLE
Add three personal research and engineering feeds

### DIFF
--- a/smallweb.txt
+++ b/smallweb.txt
@@ -3687,6 +3687,7 @@ https://anygoodthing.com/feed/
 https://anymoreanyways.bearblog.dev/feed/?type=rss
 https://aoaofox.bearblog.dev/feed/
 https://aofradkin.wordpress.com/feed
+https://aogavrilov.com/atom.xml
 https://aokozaki.tumblr.com/rss
 https://aoli.al/index.xml
 https://aolunderground.com/feed/podcast
@@ -5309,6 +5310,7 @@ https://billpg.com/feed
 https://billprin.com/rss/feed.xml
 https://billsaysthis.com/feed
 https://billshander.com/feed/
+https://billson.me/rss.xml
 https://billwadge.com/feed
 https://billy.barrow.nz/blog/feed.rss
 https://billykaplan.io/rss.xml
@@ -23509,6 +23511,7 @@ https://lproven.dreamwidth.org/data/atom
 https://lqdev.me/posts/feed.xml
 https://lqlang.org/index.xml
 https://lr0.org/index.xml
+https://lrdinsu.github.io/rss.xml
 https://lremes.com/rss.xml
 https://lsdbase.org/feed/
 https://lsferreira.net/index.xml


### PR DESCRIPTION
Adds three English-language personal feeds while keeping `smallweb.txt` locally sorted:

- `https://aogavrilov.com/atom.xml` — personal machine-learning research site; latest entry 2026-07-25.
- `https://billson.me/rss.xml` — independent personal engineering/writing site; latest entry 2026-07-03.
- `https://lrdinsu.github.io/rss.xml` — independent personal blog; latest entry 2026-05-19.

Validation performed:

- all three feed URLs return HTTP 200 and parse as Atom/RSS;
- all have an entry from the last 12 months;
- each is an English, single-author personal site with no ads or automatic cookie popup observed;
- the two additional feeds are unrelated to my site and were not already present in `smallweb.txt`;
- the three insertions are locally sorted and introduce no duplicate feed URL.

For transparency, aogavrilov.com states on its About page that editorial summaries, translations, and research guides may use owner-reviewed AI-assisted drafting against cited papers; publication metadata and full paper text remain source-derived.