### PR TITLE
Remove 8 blogspam feeds

### DIFF
--- a/smallweb.txt
+++ b/smallweb.txt
@@ -13378,7 +13378,6 @@ https://dukkha.life/feed/
 https://duksta.org/index.xml
 https://dulltooldimbulb.blogspot.com/atom.xml
 https://dumbmatter.com/feed/
-https://dumpa.co/api/blogs/rss/@dumpa
 https://dumpster.vigneshmarimuthu.com/index.xml
 https://duncan.bayne.id.au/feed.xml
 https://duncan.co/feed/atom
@@ -13413,7 +13412,6 @@ https://dusted.codes/feed/rss
 https://dustin.boston/feed
 https://dustin.lammiman.ca/feed/feed.xml
 https://dustin.works/rss.xml
-https://dustinabbott.net/feed/
 https://dustinbrett.com/rss.xml
 https://dustinbriles.com/rss/
 https://dustincurtis.com/rss.xml
@@ -26651,7 +26649,6 @@ https://namelesspete.bearblog.dev/atom.xml
 https://namelessvirtue.com/atom
 https://nameplay.org/blog/rss.xml
 https://namerology.com/feed
-https://namethatui.com/feed.xml
 https://nami.land/feed.xml
 https://namingthings.co/feed.xml
 https://namirsab.dev/rss.xml
@@ -33782,7 +33779,6 @@ https://sirupsen.com/atom.xml
 https://sirwan.info/rss.xml
 https://sistemfrater.bearblog.dev/atom.xml
 https://sistrall.it/it/feed.xml
-https://sisuonspeaks.com/rss.xml
 https://site-of-curiosities.blogspot.com/atom.xml
 https://site.bhamm-lab.com/index.xml
 https://site.fzxu.me/feed
@@ -36228,7 +36224,6 @@ https://theheatwarps.com/feed
 https://thehftguy.com/feed
 https://thehiddenport.dev/index.xml
 https://thehighergeometer.wordpress.com/feed
-https://thehighestcritic.com/feed/
 https://thehighfrontier.blog/atom
 https://thehippiesnowwearblack.org.uk/feed/
 https://thehistorianshut.com/feed/
@@ -39536,7 +39531,6 @@ https://wrywerytwreywery.stupid.pizza/rss.cgi
 https://wrywriter.ca/feed.xml
 https://ws4k.net/feed
 https://wsbj.com/sorabji/feed
-https://wskpf.com/feed.xml
 https://wsmoak.net/feed.xml
 https://wssite.vercel.app/rss.xml
 https://wstoop.co.za/index.xml
@@ -44646,7 +44640,6 @@ https://www.resourceaholic.com/feeds/posts/default
 https://www.respectfulinsolence.com/feed/
 https://www.resultsjunkies.com/feed
 https://www.ret2libc.com/feed.xml
-https://www.retirejapan.com/feed/
 https://www.retrogamescollector.com/feed/
 https://www.retronator.com/rss
 https://www.retrotimepodcast.com/feed/podcast
@@ -46007,7 +46000,6 @@ https://www.userlandia.com/home?format=rss
 https://www.usersknow.com/blog?format=rss
 https://www.usuallypragmatic.com/feed.xml
 https://www.utopiaslab.space/atom
-https://www.utterlyinteresting.com/blog-feed.xml
 https://www.uxtigers.com/blog-feed.xml
 https://www.uyar.design/feed.xml
 https://www.uzpg.me/feed.xml


### PR DESCRIPTION
Proposing the removal of the following feeds for not following the guidelines:

1. https://dustinabbott.net/feed/ (content farm with ads)
2. https://dumpa.co/api/blogs/rss/@dumpa (not in English)
3. https://namethatui.com/feed.xml (not a blog)
4. https://sisuonspeaks.com/rss.xml (entirely AI-generated as stated here: https://sisuonspeaks.com/about/)
5. https://www.retirejapan.com/feed/ (commercial business, not a personal blog but sometimes has borderline posts)
6. https://wskpf.com/feed.xml (SEO Agency, not a personal blog - borderline though with occasional personal posts)
7. https://www.utterlyinteresting.com/blog-feed.xml (content farm with ads)
8. https://thehighestcritic.com/feed/ (content farm with ads)