### PR TITLE
Remove drjohnson.com feed link

### DIFF
--- a/smallweb.txt
+++ b/smallweb.txt
@@ -13292,7 +13292,6 @@ https://drissboumlik.com/feed
 https://driventowrite.com/feed
 https://drivinginstructorblog.com/feed/
 https://drjengunter.com/feed
-https://drjohnson.com/feed/
 https://drkhsh.at/atom.xml
 https://drkottaway.com/feed
 https://drkpxl.com/feed.xml


### PR DESCRIPTION
Removed the feed link for drjohnson.com, which seems to be a content farm for a vet clinic with advertising.
