### PR TITLE
Remove casino spam sites

### DIFF
--- a/smallweb.txt
+++ b/smallweb.txt
@@ -767,7 +767,6 @@ http://realgl.blogspot.com/feeds/posts/default
 http://recombinomics.com/feed.xml
 http://redplait.blogspot.com/atom.xml
 http://relatedwork.blogspot.com/feeds/posts/default
-http://renaudguezennec.eu/index.php/feed
 http://retro.hansotten.nl/feed
 http://retromaniabysimonreynolds.blogspot.com/atom.xml
 http://retroramblings.net/?feed=rss2
@@ -37281,7 +37280,6 @@ https://tldmar.blog/atom
 https://tldr.bearblog.dev/feed/
 https://tldr.fi/feed
 https://tlmorganfieldc67665e63c-ipfgc.wpcomstaging.com/feed/
-https://tlnotes.com/feed
 https://tlohde.com/feed.xml
 https://tloriato.com/rss.xml
 https://tlvx.net/rss
@@ -46720,7 +46718,6 @@ https://yagnesh.org/rss.html
 https://yagni.club/atom
 https://yagnipedia.com/feed.xml
 https://yak.bearblog.dev/feed/
-https://yak.ventures/feed
 https://yakbuttertea.com/index.xml
 https://yakirhavin.com/rss
 https://yakko.dev/rss.xml

--- a/smallweb.txt
+++ b/smallweb.txt
@@ -41547,7 +41547,6 @@ https://www.drroyspencer.com/feed
 https://www.drugdiscovery.net/feed/
 https://www.drugwarrant.com/feed/
 https://www.dsdev.in/rss.xml
-https://www.dsebastien.net/rss/
 https://www.dshen.com/blogs/business/feed
 https://www.dthomason.com/essays/rss.xml
 https://www.dtsheffler.com/rss/index.xml


### PR DESCRIPTION
Removing 3 feeds that are presently publishing casino spam:

1. http://renaudguezennec.eu/index.php/feed
2. https://tlnotes.com/feed
3. https://yak.ventures/feed