### PR TITLE
Add The Gresql Post, plus two PostgreSQL blogs

### DIFF
--- a/smallweb.txt
+++ b/smallweb.txt
@@ -29180,6 +29180,7 @@ https://pgj11.com/feed
 https://pgjones.dev/blog/atom.xml
 https://pgl.yoyo.org/adservers/rss/news.rss
 https://pgpbpadilla.github.io/feed.xml
+https://pgsqlpgpool.blogspot.com/feeds/posts/default
 https://pgstef.github.io/feed
 https://pgwhalen.com/index.xml
 https://ph-uhl.com/rss.xml
@@ -36056,6 +36057,7 @@ https://thegraynode.io/index.xml
 https://thegreatcritique.wordpress.com/feed/
 https://thegreencodes.com/rss.xml
 https://thegreentank.blogspot.com/feeds/posts/default
+https://thegresqlpost.org/rss.xml
 https://thegustafson.com/feed.xml
 https://thehackerblog.com/feed.xml
 https://thehangedman.com/atom
@@ -39698,6 +39700,7 @@ https://www.amirsharif.com/feed.rss
 https://www.amishbhadeshia.co.uk/index.xml
 https://www.amitgawande.com/rss
 https://www.amitkohli.com/index.xml
+https://www.amitlan.com/feed.xml
 https://www.amitmerchant.com/feed.xml
 https://www.amlie.name/feed/
 https://www.amoderndilemma.com/atom


### PR DESCRIPTION
Own site:
  https://thegresqlpost.org/rss.xml

Two others, neither mine and neither previously listed, per the submission rule:
  https://pgsqlpgpool.blogspot.com/feeds/posts/default  (Tatsuo Ishii)
  https://www.amitlan.com/feed.xml  (Amit Langote)

All three inserted in sorted position. Single-author blogs, English, no ads, each with posts inside the last twelve months.
