### PR TITLE
Remove siliconopera.com again (multi-author AI content farm)

### DIFF
--- a/smallweb.txt
+++ b/smallweb.txt
@@ -33467,7 +33467,6 @@ https://silentrobots.com/index.xml
 https://silentsblog.com/feed.xml
 https://silicaspace.neocities.org/rss.xml
 https://siliconislandblog.wordpress.com/feed
-https://siliconopera.com/feed/
 https://siliconsprawl.com/feed.xml
 https://silky.bearblog.dev/index.xml
 https://silky.github.io/atom.xml


### PR DESCRIPTION
siliconopera.com is a multi-author AI content farm. It was removed in #817 on 2026-06-26.

It came back on 2026-07-23 in commit 82d2cc6, one of the bulk "new" feed imports (1,010 lines added in that commit). Removing it here again.

Worth noting this isn't a one-off. Because there's no deny-list for the import pipeline, a few other community removals have also been undone by later bulk imports:

- iampneuma.com, removed 2026-06-07, back in 82d2cc6
- pokeau.com and blog.itsnero.com, removed as NSFW on 2026-03-16, back in 82d2cc6
- classicnewyorkhistory.com, cheapestdestinationsblog.com, mywanderlust.pl, removed as blogspam on 2026-08-01, back the same day in 57e62e4

Opened #864 proposing a smallweb_rejected.txt deny-list (same idea as the existing yt_rejected.txt) so these removals stick.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
