### PR TITLE
Add Lane Belone, plus two personal blogs

### DIFF
--- a/smallweb.txt
+++ b/smallweb.txt
@@ -15078,6 +15078,7 @@ https://feeds.feedburner.com/TheGeomblog
 https://feeds.feedburner.com/TheGlowingPython
 https://feeds.feedburner.com/theifworks
 https://feeds.feedburner.com/TheMonetaryFuture
+https://feeds.feedburner.com/TheMusicOfSound
 https://feeds.feedburner.com/TheProgrammersParadox
 https://feeds.feedburner.com/TheSpacewriter
 https://feeds.feedburner.com/TheTallyRoom
@@ -30372,6 +30373,7 @@ https://rachelandrew.co.uk/feed
 https://rachelbythebay.com/w/atom.xml
 https://rachelcarmena.github.io/feed.xml
 https://racheldacus.net/feed
+https://racheldorn.blogspot.com/feeds/posts/default
 https://racheleditullio.com/feed
 https://rachelsruminations.com/feed/
 https://rachit.pl/post/atom.xml
@@ -42934,6 +42936,7 @@ https://www.lampysecurity.com/blog-feed.xml
 https://www.lanabananart.art/atom
 https://www.landontownsend.com/blog-feed.xml
 https://www.landow.dev/index.xml
+https://www.lanebelone.com/rss.xml
 https://www.languagejones.com/blog-1?format=rss
 https://www.languagesforsyste.ms/index.xml
 https://www.lapsedordinary.net/feed


### PR DESCRIPTION
Own site:
  https://www.lanebelone.com/rss.xml

Two others, neither mine and neither previously listed, per the submission rule:
  https://racheldorn.blogspot.com/feeds/posts/default  (Rachel Dorn, ceramic sculptor)
  https://feeds.feedburner.com/TheMusicOfSound  (Tim Prebble, sound designer)

All three inserted in sorted position. Single-author blogs, English, no ads, no popups, each with posts inside the last twelve months. All three feeds verified returning 200.