### PR TITLE
Removing 3 content farms, adding exocomics

### DIFF
--- a/smallcomic.txt
+++ b/smallcomic.txt
@@ -106,6 +106,7 @@ https://electrictransit.wordpress.com/feed/atom
 https://elephant.town/comic/rss
 https://epicchaoswebcomic.com/comic/feed/
 https://existentialcomics.com/rss.xml
+https://www.exocomics.com/index.xml
 https://explosm.net/rss.xml
 https://farragone.tumblr.com/rss
 https://fatecomic.com/rss

--- a/smallweb.txt
+++ b/smallweb.txt
@@ -9705,7 +9705,6 @@ https://cheng.st/atom.xml
 https://chengweihu.com/rss
 https://chenhuijing.com/rss.xml
 https://chentiangemalc.wordpress.com/feed/
-https://chequer-board.net/feed/
 https://cherla.org/index.xml
 https://cherryblossomwatch.com/feed/
 https://cherrylkd.wordpress.com/feed
@@ -14145,7 +14144,6 @@ https://ericneyman.wordpress.com/feed
 https://ericniebler.com/feed
 https://ericnielsen.blog/feed/
 https://ericnormand.me/feed
-https://ericpetersautos.com/atom
 https://ericphanson.com/index.xml
 https://ericportis.com/feed
 https://ericposner.com/feed
@@ -24020,7 +24018,6 @@ https://markdotto.com/rss.xml
 https://markentier.tech/feed.atom.xml
 https://markesler.com/index.xml
 https://markessien.com/index.xml
-https://market-ticker.org/akcs-www?rss=Market-Ticker
 https://marketdesigner.blogspot.com/feeds/posts/default
 https://marketmonetarist.com/feed/
 https://marketoonist.com/feed/atom
@@ -29631,7 +29628,6 @@ https://preahs.com/rss.xml
 https://precastreinforced.co.uk/feed
 https://precompile.com/feed.xml
 https://predatorialism.com/feed/
-https://predictandprofit.io/feed.xml
 https://predictivehistory.com/rss/
 https://predr.ag/atom.xml
 https://predragtasevski.com/feed.xml
@@ -34855,7 +34851,6 @@ https://swissmacuser.ch/feed
 https://switchupcb.com/feed/
 https://switowski.com/feed.xml
 https://swizec.com/rss.xml
-https://swling.com/blog/feed/
 https://swlody.dev/index.xml
 https://swoleateveryheight.blogspot.com/feeds/posts/default
 https://swordandsignals.com/feed.xml
@@ -35691,7 +35686,6 @@ https://thedaemons.space/Log/index.rss
 https://thedailybeatblog.blogspot.com/feeds/posts/default
 https://thedailyplasma.blog/feed/
 https://thedailyviz.com/feed.xml
-https://thedanishdream.com/feed/
 https://thedanplan.com/feed
 https://thedarkside.frantzmiccoli.com/feed.xml
 https://thedataquarry.com/rss.xml
@@ -35717,7 +35711,6 @@ https://thedorkweb.bearblog.dev/feed/
 https://thedruidsgarden.com/feed
 https://thedulinreport.com/feed
 https://thedysfunctionalworldof.blogspot.com/feeds/posts/default
-https://theeastcoastkitchen.com/feed/
 https://theeconomyofmeaning.com/feed/
 https://theeffortfuleducator.com/feed
 https://theelandor.github.io/index.xml
@@ -38340,7 +38333,6 @@ https://waituntilnextyear.com/feed
 https://waiyanyoon.com/atom
 https://wakamoleguy.com/feed.xml
 https://wakelift.de/rss
-https://wakingupstory.com/feed/
 https://wakunguma.com/rss.xml
 https://walac.github.io/feed.xml
 https://walat.eu/index.xml

--- a/smallweb.txt
+++ b/smallweb.txt
@@ -2703,7 +2703,6 @@ https://aliceevebob.com/feed/
 https://alicegg.tech/feed.xml
 https://alicegordenker.wordpress.com/feed/
 https://alicehsu.blog/index.xml
-https://alicekeeler.com/feed/
 https://alicekile.dev/feed/feed.xml
 https://alichraghi.github.io/index.xml
 https://alicja.space/feed.xml
@@ -39479,7 +39478,6 @@ https://www.annashipman.co.uk/atom.xml
 https://www.annehelmond.nl/feed/
 https://www.annemiekeverhoeff.nl/blog?format=rss
 https://www.annewheaton.com/feed
-https://www.annielytics.com/feed/
 https://www.anomalogue.com/feed/
 https://www.anongeta.com/feed/feed.xml
 https://www.anonoz.com/feed.xml
@@ -41861,7 +41859,6 @@ https://www.inspec.me/blog-feed.xml
 https://www.institute4learning.com/feed/
 https://www.integralist.co.uk/rss.xml
 https://www.integralthelema.com/feed/
-https://www.intelligent-people.org/atom
 https://www.interconnected.org/home/feed
 https://www.interesly.com/feed
 https://www.interestingideas.com/feed/

--- a/smallweb.txt
+++ b/smallweb.txt
@@ -15430,7 +15430,6 @@ https://foonathan.net/feed.xml
 https://foosel.net/blog/index.xml
 https://foosoft.net/feeds/posts.atom
 https://foote.pub/feed.xml
-https://footloosedev.com/feed/
 https://footnote4a.org/footnote4a/feed/quick-takes.xml
 https://footnotes2plato.com/feed/
 https://foragerchef.com/feed

--- a/smallweb.txt
+++ b/smallweb.txt
@@ -24991,7 +24991,6 @@ https://metalbyexample.com/feed
 https://metalheadcnc.com/rss.xml
 https://metalhearf.fr/index.xml
 https://metallapan.se/index.xml
-https://metallicman.com/feed/
 https://metametamedieval.com/feed/
 https://metamood.ai/atom/
 https://metamorphingmachine.neocities.org/rss/rss.xml


### PR DESCRIPTION
Remove content farms:

1. alicekeeler.com (Teacher Tech Tip content farm)
2. annielytics.com (significant SEO Spam on AI)
3. www.intelligent-people.org (high publishing cadence promoting sales of AI books)
4. metallicman.com (seems to have been hacked and is now republishing rewritten reddit posts?)
5. footloosedev.com (business selling travel influencer courses)
6. chequer-board.net (AI content farm)
7. predictandprofit.io (not a personal blog, a commercial trading bot)
8. thedanishdream.com (not a personal blog, it's a course/content farm for immigration)
9. ericpetersautos.com (AI generated content farm?)
10. theeastcoastkitchen.com (has ads)
11. swling.com (multiple authors, not a personal blog)
12. market-ticker.org (I would just open it..., but has ads)

Add exocomics.com - a small web comic.