### PR TITLE
Remove 3 feed links from smallweb.txt

### DIFF
--- a/smallweb.txt
+++ b/smallweb.txt
@@ -24747,7 +24747,6 @@ https://theangrypharmacist.com/index.xml
 https://theanimatronicmenagerie.wordpress.com/feed/
 https://theantistartup.com/rss/
 https://theapartmentwoodworker.com/feed/
-https://theapiarist.org/rss/
 https://theappleandtherabbit.bearblog.dev/feed/
 https://theappsscriptlab.com/feed/
 https://theaq.blog/feed.xml
@@ -27306,7 +27305,6 @@ https://www.akselmo.dev/feed.xml
 https://www.akula-games.com/feed
 https://www.al-vimh.net/feed/
 https://www.al3rez.com/rss
-https://www.al6400.com/blog/feed/
 https://www.alam.ph/atom/
 https://www.alantsen.com/rss/
 https://www.alanwsmith.com/feeds/posts.xml
@@ -31282,7 +31280,6 @@ https://www.theliberatedmathematician.com/feed/
 https://www.thelinklist.dev/index.xml
 https://www.thelins.se/johan/blog/feed/
 https://www.thelis.org/rss.xml
-https://www.thelongestwayhome.com/blog/feed/
 https://www.themacaque.com/feed
 https://www.themathcitadel.com/rss.xml
 https://www.themathdoctors.org/feed/


### PR DESCRIPTION
These feeds no longer meet the quality bar for the list:

- https://www.al6400.com/blog/feed/          site active but ad-heavy
- https://theapiarist.org/rss/                spam/commercial content
- https://www.thelongestwayhome.com/blog/feed/  tons of ads
