### PR TITLE
Add leaddev.com feed

### DIFF
--- a/smallweb.txt
+++ b/smallweb.txt
@@ -15489,6 +15489,7 @@ https://le.qun.ch/en/blog/feed.xml
 https://lea.codes/rss.xml
 https://lea.verou.me/feed.xml
 https://lea.xn--q9jyb4c/feed/
+https://leaddev.com/feed
 https://leadprompt.sh/atom.xml
 https://leaflessca.wordpress.com/feed/
 https://leaguedonation.com/feed.xml


### PR DESCRIPTION
Adds https://leaddev.com/feed to `smallweb.txt`, placed so the file stays in its existing case-insensitive (`sort -f`) order. Net diff is +1 line, 0 removed. The domain did not already appear in the list, and the feed returns HTTP 200 with valid RSS.

One thing for maintainers to weigh: LeadDev is a multi-author engineering-leadership publication, not a personal blog. Flagging it explicitly against the "only personal blogs may be submitted (no multi-author blogs)" rule so you can close this quickly if it is out of scope.

🤖 Generated with [Claude Code](https://claude.com/claude-code)