### PR TITLE
Add davidgolverdingen.nl, docsbydesign.com and tomekkorbak.com

### DIFF
--- a/smallweb.txt
+++ b/smallweb.txt
@@ -150,6 +150,7 @@ http://datakurre.pandala.org/rss.xml
 http://davescomicheroes.blogspot.com/feeds/posts/default
 http://davetrott.co.uk/feed/atom/
 http://davidbstein.com/feed
+https://davidgolverdingen.nl/feed.xml
 http://davidschalliol.com/blog/feed/
 https://david-osipov.vision/en/atom.xml
 https://david-osipov.vision/ru/atom.xml
@@ -9731,6 +9732,7 @@ https://docpop.org/feed/
 https://docs.j7k6.net/feed.xml
 https://docs.lextudio.com/blog/feed.xml
 https://docs.oldmartijntje.nl/index.xml
+https://docsbydesign.com/feed/
 https://docsgoblin.com/feed.xml
 https://docthisway.com/feed/
 https://doctordizzy.space/feed.xml
@@ -28372,6 +28374,7 @@ https://tomdebruijn.com/feed.xml
 https://tomdehnel.com/rss.xml
 https://tomdekan.com/feed.xml
 https://tomekdev.com/rss.xml
+https://tomekkorbak.com/feed.xml
 https://tomekw.com/atom.xml
 https://tomer-barak.github.io/feed.xml
 https://tomeraberba.ch/rss.xml


### PR DESCRIPTION
## Checklist
- [x] I have read the [guidelines](https://github.com/kagisearch/smallweb/blob/main/README.md#%EF%B8%8F-guidelines-for-site-inclusion-to-the-list-%EF%B8%8F)

Also if submitting your own website you must add at least 2 other sites that are not yours (and are not in list yet) in the same commit:
1. https://tomekkorbak.com/feed.xml — Tomek Korbak, AI safety research (monitoring LLM agents for misalignment). Single-author personal site, English, no ads or popups, latest post July 2026.
2. https://docsbydesign.com/feed/ — Bob Watson, API documentation and how AI agents actually read docs. Single-author personal blog, self-hosted WordPress, English, no ads or popups, latest post February 2026.

The third entry, https://davidgolverdingen.nl/feed.xml, is my own site: a single-author blog on MCP architecture and context engineering, English, no ads, no popups, latest post August 2026.

On the LLM guidelines: the posts are written from systems I build and run in production, for example a markdown-based ticket board that 12 people use daily across 10 repositories, and from the codebase and practice behind them rather than from research or summary. Drafting is done with Claude from my own outlines and notes, then reviewed and corrected by me. This is acknowledged site-wide in the footer of every page: "Posts here are drafted with Claude and validated by the author against production experience."
