### PR TITLE
Add Chovy's Blog, rachelbythebay and I Am Santo

### DIFF
--- a/smallweb.txt
+++ b/smallweb.txt
@@ -2541,6 +2541,7 @@ https://antfu.me/feed.xml
 https://antharris.co/feed/
 https://anthonnyquerouil.me/rss/
 https://anthony-calandra.com/feed.xml
+https://anthony.dev.profullstack.com/blog/feed.xml
 https://anthony.noided.media/feed.xml
 https://anthonyalicea.com/feed/feed.xml
 https://anthonybonato.com/feed/atom/
@@ -13574,6 +13575,7 @@ https://iampavel.dev/rss.xml
 https://iampj.xyz/feed.xml
 https://iamrain.net/atom/
 https://iamrob.in/blog-rss.xml
+https://iamsanto.com/feed/
 https://iamschulz.com/index.xml
 https://iamstelios.com/atom.xml
 https://iamsteve.me/feed.xml
@@ -23160,6 +23162,7 @@ https://rachel.blog/feed/
 https://rachel.fast.ai/index.xml
 https://rachel.fyi/rss.xml
 https://rachelandrew.co.uk/feed/
+https://rachelbythebay.com/w/atom.xml
 https://racheldacus.net/feed/
 https://racheldorn.blogspot.com/feeds/posts/default
 https://racheleditullio.com/feed/


### PR DESCRIPTION
Three personal blogs, each inserted in sorted position. One is mine, so per the guidelines it comes with two that are not.

| Feed | Author | Latest post |
| --- | --- | --- |
| `https://anthony.dev.profullstack.com/blog/feed.xml` | Anthony "chovy" Ettinger (mine) | 2026-08-14 |
| `https://rachelbythebay.com/w/atom.xml` | Rachel Kroll | 2026-01-16 |
| `https://iamsanto.com/feed/` | Jason Santo — fiction, poetry, music | 2026-01-28 |

Checked against the guidelines before submitting:

- **Not already listed** — none of the three appear in `smallweb.txt` (including under their canonical domains after redirects).
- **English** — all three declare `en`/`en-us`.
- **Personal, single-author blogs** — no multi-author or company blogs.
- **Recency** — most recent posts are 0, 7 and 6.5 months old, all inside the 12-month window.
- **No advertisements** — no ad networks or affiliate scripts in the served HTML.
- **No popups** — no newsletter modals or cookie banners.
- **Sorted** — inserted between `anthony-calandra.com` / `anthony.noided.media`, `iamrob.in` / `iamschulz.com`, and `rachelandrew.co.uk` / `racheldacus.net` respectively.