### PR TITLE
Add stik.wtf + 2 other personal sites

### DIFF
--- a/smallweb.txt
+++ b/smallweb.txt
@@ -6824,6 +6824,7 @@ https://cafelog.fr:443/feed/
 https://caffeinated.bearblog.dev/feed/
 https://caffeinatedcode.com/index.xml
 https://caffeinatedgorillas.com/atom/
+https://caffeine.wiki/atom.xml
 https://caffeineandlasers.com/feed.xml
 https://caffeineforge.com/feed/
 https://cafuego.net/rss.xml.php
@@ -24561,6 +24562,7 @@ https://sahara-overland.com/feed/
 https://saharshlaud.hashnode.dev/rss.xml
 https://sahbichaieb.com/rss.xml
 https://saheb.github.io/blog/index.xml
+https://sahil.im/feed.xml
 https://sahilarora.in/blog/rss.xml
 https://sahilkapoor.com/rss/
 https://sahilparikh.com/feed/feed.xml
@@ -26546,6 +26548,7 @@ https://stigward.github.io/feed.xml
 https://stijn.tintel.eu/rss.xml
 https://stijnbruers.wordpress.com/feed/
 https://stijndewitt.com/feed/
+https://stik.wtf/index.xml
 https://stilgherrian.com/feed/atom/
 https://stillhere.blog/posts_feed
 https://stillig.net/feed.xml


### PR DESCRIPTION
Adding three personal-site feeds, each verified active and single-author:

- **https://stik.wtf/index.xml** — my own site: hand-built Hugo, self-hosted on my own hardware; project update log posts through Aug 2026 (launched and actively updated this month).
- **https://sahil.im/feed.xml** — personal blog (Linux, publishing workflows); latest post July 2026. Not previously in the list.
- **https://caffeine.wiki/atom.xml** — personal wiki/blog of a longtime sysop; feed updated 2026-08-15 (today, at time of PR). Not previously in the list.

All three are English, non-commercial, and hand-made. Placed to keep the file's domain ordering.

🤖 Generated with [Claude Code](https://claude.com/claude-code)