### PR TITLE
Remove ajaxdavis.dev

### DIFF
--- a/smallweb.txt
+++ b/smallweb.txt
@@ -1524,7 +1524,6 @@ https://aiyorama.bearblog.dev/feed/
 https://aj.bourg.family/rss.xml
 https://ajaishar.github.io/feed.xml
 https://ajantrik.bearblog.dev/feed/
-https://ajaxdavis.dev/rss.xml
 https://ajaxnwnk.blogspot.com/feeds/posts/default
 https://ajaykarwal.com/feed.xml
 https://ajazz.fromthesuperhighway.com/rss.xml


### PR DESCRIPTION
This site's main feed mixes together Essays and Devlog. Devlogs are fully AI-generated, and there doesn't seem to be a feed for only the essays.