### PR TITLE
Submitting public bookmarks feed from chrkrhc (not affiliated, but like the feed)

### DIFF
--- a/smallweb.txt
+++ b/smallweb.txt
@@ -11404,6 +11404,7 @@ https://feeds.hackercodex.com/feeds/main
 https://feeds.hanselman.com/ScottHanselman
 https://feeds.jimkang.com/weblog/feed.xml
 https://feeds.kottke.org/main
+https://feeds.later.place/chrkrhc@omg.lol
 https://feeds.roshangeorge.dev/wiki.roshangeorge.dev.xml
 https://feeds.thefinanser.com/feed/
 https://feeds.thejeshgn.com/thejeshgn/


### PR DESCRIPTION

## Checklist
- [x] I have read the [guidelines](https://github.com/kagisearch/smallweb/blob/main/README.md#%EF%B8%8F-guidelines-for-site-inclusion-to-the-list-%EF%B8%8F)

The submitted site is a public bookmark list that functions slightly like a microblog of link sharing - I don't see anything in the guidelines prohibiting that, but also nothing including it. I hope it's an allowed submission.

This is not my own website and I am not affiliated in any way with either the platform or the shared feed.