### PR TITLE
Remove jonworth.eu for containing paywalled content

### DIFF
--- a/smallweb.txt
+++ b/smallweb.txt
@@ -15754,7 +15754,6 @@ https://jonthysell.com/feed/
 https://jonw.mayhem.academy/feed/
 https://jonwear.com/feed.xml
 https://jonwoodlief.com/feed
-https://jonworth.eu/rss/
 https://jonyablonski.com/index.xml
 https://joodaloop.com/index.xml
 https://joomy.korkutblech.com/atom.xml


### PR DESCRIPTION
Removed the RSS feed link for jonworth.eu because it contains paywalled content.

Examples:
- https://jonworth.eu/passengers-cant-complain-about-trains-they-cannot-take-because-they-dont-exist-in-defence-of-german-rail/
- https://jonworth.eu/the-crossborderrail-method-and-a-post-summer-break-round-up/
- https://jonworth.eu/the-end-for-freiburg-colmar-but-was-there-ever-a-start/