### PR TITLE
Remove simplermachines.com: Paywall

### DIFF
--- a/smallweb.txt
+++ b/smallweb.txt
@@ -36414,7 +36414,6 @@ https://www.simonrumble.com/blog/feed.atom
 https://www.simonswords.com/rss/
 https://www.simontaylorsblog.com/feed/
 https://www.simonwardjones.co.uk/index.xml
-https://www.simplermachines.com/rss/
 https://www.simplykyra.com/rss/
 https://www.sinasamaki.com/rss/
 https://www.sindark.com/feed/


### PR DESCRIPTION
Removes `simplermachines.com` as several articles are paywalled: https://kagi.com/smallweb/?url=https%3A%2F%2Fwww.simplermachines.com%2Fnmd-exq-11-60-guests%2F

<img width="1124" height="1076" alt="Screenshot" src="https://github.com/user-attachments/assets/14e6c4cc-6161-4f36-a005-be4745651653" />


## Checklist
- [x] I have read the [guidelines](https://github.com/kagisearch/smallweb/blob/main/README.md#%EF%B8%8F-guidelines-for-site-inclusion-to-the-list-%EF%B8%8F)
