### PR TITLE
Add everydaycontentment.com (+2 other new personal blogs)

### DIFF
--- a/smallweb.txt
+++ b/smallweb.txt
@@ -1121,6 +1121,7 @@ https://abhipandey.com/index.xml
 https://abhirath.me/feed.xml
 https://abhiroop.github.io/feed.xml
 https://abhisaha.com/rss.xml
+https://abhishe.com/rss.xml
 https://abhishek-shankar.com/rss.xml
 https://abhishekpandit.me/feed.xml
 https://abhvio.us/index.xml
@@ -11556,6 +11557,7 @@ https://evertpot.com/atom.xml
 https://everwas.com/feed/
 https://everybitthejourney.com/feed/
 https://everybodyslibraries.com/feed/
+https://everydaycontentment.com/rss.xml
 https://everydaymagic.bearblog.dev/feed/
 https://everydaysuperpowers.dev/feed/
 https://everygame.tumblr.com/rss
@@ -14075,6 +14077,7 @@ https://hounie.me/rss.xml
 https://householderkarl.bearblog.dev/feed/
 https://householderkarl.com/feed/
 https://houseofkyle.com/feed/
+https://houseoflief.com/feed.xml
 https://houserat.net/feed
 https://houstonhistoricretail.com/feed/
 https://hoverbear.org/rss.xml


### PR DESCRIPTION
Adds three personal blog feeds, sorted in place:

- `https://everydaycontentment.com/rss.xml` — Everyday Contentment, a human-written slow-living diary from Aotearoa New Zealand by Posie Clark, publishing since January 2023 (migrated from Blogger). Submitted on the author's behalf, so per the self-submission rule two other new sites are included:
- `https://abhishe.com/rss.xml` — Abhishek Singh's personal blog, latest post Aug 2026.
- `https://houseoflief.com/feed.xml` — House of Lief, personal blog/zine, latest post Sep 2026.

All three: single-author, English, recent posts, no ads or popups found.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
